### PR TITLE
Exposes all registered states via `States` property

### DIFF
--- a/source/Lite.State.Tests/Lite.State.Tests.csproj
+++ b/source/Lite.State.Tests/Lite.State.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.1" />
     <PackageReference Include="MSTest" Version="4.0.1" />
   </ItemGroup>
 

--- a/source/Lite.State.Tests/StateTests/BasicStateTests.cs
+++ b/source/Lite.State.Tests/StateTests/BasicStateTests.cs
@@ -2,6 +2,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Linq;
 
 namespace Lite.State.Tests.StateTests;
 
@@ -38,9 +39,17 @@ public class BasicStateTests
 
     // Assert Results
     var ctxFinalParams = machine.Context.Parameters;
-
     Assert.IsNotNull(ctxFinalParams);
     Assert.AreEqual(TestValue, ctxFinalParams[ParameterKeyTest]);
+
+    var enums = Enum.GetValues(typeof(StateId)).Cast<StateId>();
+
+    // Ensure all states are hit
+    Assert.AreEqual(enums.Count(), machine.States.Count());
+    Assert.IsTrue(enums.All(k => machine.States.Keys.Contains(k)));
+
+    // Ensure they're in order
+    Assert.IsTrue(enums.SequenceEqual(machine.States.Keys));
   }
 
   /// <summary>Defines State Enum ID and `OnSuccess` transitions from the `RegisterStateEx` method.</summary>
@@ -62,7 +71,6 @@ public class BasicStateTests
 
     // Assert Results
     var ctxFinalParams = machine.Context.Parameters;
-
     Assert.IsNotNull(ctxFinalParams);
     Assert.AreEqual(TestValue, ctxFinalParams[ParameterKeyTest]);
   }

--- a/source/Lite.State/StateMachine.cs
+++ b/source/Lite.State/StateMachine.cs
@@ -39,9 +39,15 @@ public sealed partial class StateMachine<TState> where TState : struct, Enum
     _logger = logs;
   }
 
+  /// <summary>Gets the context payload passed between the states, and contains methods for transitioning to the next state.</summary>
   public Context<TState> Context { get; private set; } = default!;
 
+  /// <summary>Gets or sets the default timeout (3000ms default) to be used by <see cref="CommandState{TState}"/>'s OnTimeout.</summary>
   public int DefaultTimeoutMs { get; set; } = 3000;
+
+  /// <summary>Gets the collection of all registered states.</summary>
+  /// <remarks>Exposed for validations, debugging, etc.</remarks>
+  public Dictionary<TState, IState<TState>> States => _states;
 
   public void RegisterState(IState<TState> state)
   {


### PR DESCRIPTION
Exposes all registered states via `States` read-only property. Added sample unit test as an example to ensure all states are hit

```cs
var states = machine.States;
```