### PR TITLE
Renamed RegisterCompositeChild to RegisterSubComposite

### DIFF
--- a/source/Lite.StateMachine.Tests/StateTests/CompositeStateTest.cs
+++ b/source/Lite.StateMachine.Tests/StateTests/CompositeStateTest.cs
@@ -198,7 +198,7 @@ public class CompositeStateTest : TestBase
       .RegisterState<State1>(CompositeL3.State1, CompositeL3.State2)
       .RegisterComposite<State2>(CompositeL3.State2, initialChildStateId: CompositeL3.State2_Sub1, onSuccess: CompositeL3.State3)
       .RegisterSubState<State2_Sub1>(CompositeL3.State2_Sub1, parentStateId: CompositeL3.State2, onSuccess: CompositeL3.State2_Sub2)
-      .RegisterCompositeChild<State2_Sub2>(CompositeL3.State2_Sub2, parentStateId: CompositeL3.State2, initialChildStateId: CompositeL3.State2_Sub2_Sub1, onSuccess: CompositeL3.State2_Sub3)
+      .RegisterSubComposite<State2_Sub2>(CompositeL3.State2_Sub2, parentStateId: CompositeL3.State2, initialChildStateId: CompositeL3.State2_Sub2_Sub1, onSuccess: CompositeL3.State2_Sub3)
       .RegisterSubState<State2_Sub2_Sub1>(CompositeL3.State2_Sub2_Sub1, parentStateId: CompositeL3.State2_Sub2, onSuccess: CompositeL3.State2_Sub2_Sub2)
       .RegisterSubState<State2_Sub2_Sub2>(CompositeL3.State2_Sub2_Sub2, parentStateId: CompositeL3.State2_Sub2, onSuccess: CompositeL3.State2_Sub2_Sub3)
       .RegisterSubState<State2_Sub2_Sub3>(CompositeL3.State2_Sub2_Sub3, parentStateId: CompositeL3.State2_Sub2, onSuccess: null)
@@ -228,7 +228,7 @@ public class CompositeStateTest : TestBase
 
     // Note that "State2" is a Composite state.
     // When Context is NOT persisted, it will be removed on the next substate.
-    Assert.AreEqual("[Keys-State2]: State1,State2", msgService.Messages[1]);
+    Assert.AreEqual("[Keys-State2]: State1,State2!Anchor,State2!TEMP,State2", msgService.Messages[1]);
 
     if (contextIsPersistent)
     {
@@ -245,8 +245,9 @@ public class CompositeStateTest : TestBase
         "[Keys-State3]: State1,State2!Anchor,State3",
         msgService.Messages[msgService.Messages.Count - 1]);
 
-      Assert.AreEqual(4, msgService.Counter2);
-      Assert.AreEqual(7, msgService.Counter3);
+      // Counter2==7: State1,State2!Anchor,State2!TEMP,State2,State2_Sub1,State2_Sub2!Anchor,State2_Sub3
+      Assert.AreEqual(7, msgService.Counter2);
+      Assert.AreEqual(11, msgService.Counter3);
     }
   }
 }

--- a/source/Lite.StateMachine.Tests/TestData/States/CompositeL3DiStates.cs
+++ b/source/Lite.StateMachine.Tests/TestData/States/CompositeL3DiStates.cs
@@ -63,8 +63,8 @@ public class State2(IMessageService msg, ILogger<State2> log)
 
   public override Task OnExit(Context<CompositeL3> context)
   {
-    // Expected Count: 4 - State2_Sub2 is composite; therefore, discarded.
-    // State1,State2,State2_Sub1,State2_Sub3
+    // Expected Count: 7 - State2_Sub2 is composite; therefore, discarded.
+    // State1,State2!Anchor,State2!TEMP,State2,State2_Sub1,State2_Sub2!Anchor,State2_Sub3
     MessageService.Counter2 = context.Parameters.Count;
     return base.OnExit(context);
   }

--- a/source/Lite.StateMachine/IStateMachine.cs
+++ b/source/Lite.StateMachine/IStateMachine.cs
@@ -55,7 +55,7 @@ public interface IStateMachine<TStateId>
   /// <param name="onFailure">Optional transition to next state on failure.</param>
   /// <returns>State machine instance.</returns>
   /// <typeparam name="TCompositeParent">Composite State Class.</typeparam>
-  StateMachine<TStateId> RegisterCompositeChild<TCompositeParent>(TStateId stateId, TStateId parentStateId, TStateId initialChildStateId, TStateId? onSuccess = null, TStateId? onError = null, TStateId? onFailure = null)
+  StateMachine<TStateId> RegisterSubComposite<TCompositeParent>(TStateId stateId, TStateId parentStateId, TStateId initialChildStateId, TStateId? onSuccess = null, TStateId? onError = null, TStateId? onFailure = null)
     where TCompositeParent : class, IState<TStateId>;
 
   /// <summary>Registers a regular or command state (optionally with transitions).</summary>

--- a/source/Lite.StateMachine/StateMachine.cs
+++ b/source/Lite.StateMachine/StateMachine.cs
@@ -103,34 +103,6 @@ public sealed partial class StateMachine<TStateId> : IStateMachine<TStateId>
   }
 
   /// <inheritdoc/>
-  /// <remarks>Renaming to, "RegisterSubComposite" to match "RegisterSubState".</remarks>
-  public StateMachine<TStateId> RegisterCompositeChild<TCompositeParent>(
-    TStateId stateId,
-    TStateId parentStateId,
-    TStateId initialChildStateId,
-    TStateId? onSuccess = null,
-    TStateId? onError = null,
-    TStateId? onFailure = null)
-    where TCompositeParent : class, IState<TStateId>
-  {
-    if (!_states.TryGetValue(parentStateId, out var pr) || !pr.IsCompositeParent)
-      throw new ParentStateMustBeCompositeException($"Parent state '{parentStateId}' must be registered as a composite state.");
-
-    // NOTE (2025-12-28 DS): This is already caught by the base method
-    if (_states.ContainsKey(stateId))
-      throw new DuplicateStateException($"Composite child state '{stateId}' already registered.");
-
-    return RegisterState<TCompositeParent>(
-      stateId: stateId,
-      onSuccess: onSuccess,
-      onError: onError,
-      onFailure: onFailure,
-      parentStateId: parentStateId,
-      isCompositeParent: true,
-      initialChildStateId: initialChildStateId);
-  }
-
-  /// <inheritdoc/>
   public StateMachine<TStateId> RegisterState<TStateClass>(TStateId stateId, TStateId? onSuccess = null)
     where TStateClass : class, IState<TStateId>
   {
@@ -168,6 +140,33 @@ public sealed partial class StateMachine<TStateId> : IStateMachine<TStateId>
     _states[stateId] = reg;
 
     return this;
+  }
+
+  /// <inheritdoc/>
+  public StateMachine<TStateId> RegisterSubComposite<TCompositeParent>(
+    TStateId stateId,
+    TStateId parentStateId,
+    TStateId initialChildStateId,
+    TStateId? onSuccess = null,
+    TStateId? onError = null,
+    TStateId? onFailure = null)
+    where TCompositeParent : class, IState<TStateId>
+  {
+    if (!_states.TryGetValue(parentStateId, out var pr) || !pr.IsCompositeParent)
+      throw new ParentStateMustBeCompositeException($"Parent state '{parentStateId}' must be registered as a composite state.");
+
+    // NOTE (2025-12-28 DS): This is already caught by the base method
+    if (_states.ContainsKey(stateId))
+      throw new DuplicateStateException($"Composite child state '{stateId}' already registered.");
+
+    return RegisterState<TCompositeParent>(
+      stateId: stateId,
+      onSuccess: onSuccess,
+      onError: onError,
+      onFailure: onFailure,
+      parentStateId: parentStateId,
+      isCompositeParent: true,
+      initialChildStateId: initialChildStateId);
   }
 
   /// <inheritdoc/>


### PR DESCRIPTION
## Details

* Renamed RegisterCompositeChild to RegisterSubComposite, so we can match naming conventions of RegisterSubState.
* Fixed IsContextPersistent test (previously not checked in)

## Linked To Issue/Feature

* #60
* #62
* #14
