### PR TITLE
#77 - Ability to get Context PreviousStateId

### DIFF
--- a/source/Lite.StateMachine.Tests/StateTests/CompositeStateTest.cs
+++ b/source/Lite.StateMachine.Tests/StateTests/CompositeStateTest.cs
@@ -186,20 +186,10 @@ public class CompositeStateTest : TestBase
     var msgService = services.GetRequiredService<IMessageService>();
     Func<Type, object?> factory = t => ActivatorUtilities.CreateInstance(services, t);
 
-    var machine = new StateMachine<CompositeL3>(factory);
-
-    machine
-      .RegisterState<State1>(CompositeL3.State1, CompositeL3.State2)
-      .RegisterComposite<State2>(CompositeL3.State2, initialChildStateId: CompositeL3.State2_Sub1, onSuccess: CompositeL3.State3)
-      .RegisterSubState<State2_Sub1>(CompositeL3.State2_Sub1, parentStateId: CompositeL3.State2, onSuccess: CompositeL3.State2_Sub2)
-      .RegisterSubComposite<State2_Sub2>(CompositeL3.State2_Sub2, parentStateId: CompositeL3.State2, initialChildStateId: CompositeL3.State2_Sub2_Sub1, onSuccess: CompositeL3.State2_Sub3)
-      .RegisterSubState<State2_Sub2_Sub1>(CompositeL3.State2_Sub2_Sub1, parentStateId: CompositeL3.State2_Sub2, onSuccess: CompositeL3.State2_Sub2_Sub2)
-      .RegisterSubState<State2_Sub2_Sub2>(CompositeL3.State2_Sub2_Sub2, parentStateId: CompositeL3.State2_Sub2, onSuccess: CompositeL3.State2_Sub2_Sub3)
-      .RegisterSubState<State2_Sub2_Sub3>(CompositeL3.State2_Sub2_Sub3, parentStateId: CompositeL3.State2_Sub2, onSuccess: null)
-      .RegisterSubState<State2_Sub3>(CompositeL3.State2_Sub3, parentStateId: CompositeL3.State2, onSuccess: null)
-      .RegisterState<State3>(CompositeL3.State3, onSuccess: null);
-
+    // Act
+    var machine = GenerateStateMachineL3(new StateMachine<CompositeL3>(factory));
     var uml = machine.ExportUml([CompositeL3.State1], includeLegend: false);
+
     Assert.IsNotNull(uml);
     Console.WriteLine(uml);
   }
@@ -229,18 +219,7 @@ public class CompositeStateTest : TestBase
     var msgService = services.GetRequiredService<IMessageService>();
     Func<Type, object?> factory = t => ActivatorUtilities.CreateInstance(services, t);
 
-    var machine = new StateMachine<CompositeL3>(factory, null, isContextPersistent: contextIsPersistent);
-
-    machine
-      .RegisterState<State1>(CompositeL3.State1, CompositeL3.State2)
-      .RegisterComposite<State2>(CompositeL3.State2, initialChildStateId: CompositeL3.State2_Sub1, onSuccess: CompositeL3.State3)
-      .RegisterSubState<State2_Sub1>(CompositeL3.State2_Sub1, parentStateId: CompositeL3.State2, onSuccess: CompositeL3.State2_Sub2)
-      .RegisterSubComposite<State2_Sub2>(CompositeL3.State2_Sub2, parentStateId: CompositeL3.State2, initialChildStateId: CompositeL3.State2_Sub2_Sub1, onSuccess: CompositeL3.State2_Sub3)
-      .RegisterSubState<State2_Sub2_Sub1>(CompositeL3.State2_Sub2_Sub1, parentStateId: CompositeL3.State2_Sub2, onSuccess: CompositeL3.State2_Sub2_Sub2)
-      .RegisterSubState<State2_Sub2_Sub2>(CompositeL3.State2_Sub2_Sub2, parentStateId: CompositeL3.State2_Sub2, onSuccess: CompositeL3.State2_Sub2_Sub3)
-      .RegisterSubState<State2_Sub2_Sub3>(CompositeL3.State2_Sub2_Sub3, parentStateId: CompositeL3.State2_Sub2, onSuccess: null)
-      .RegisterSubState<State2_Sub3>(CompositeL3.State2_Sub3, parentStateId: CompositeL3.State2, onSuccess: null)
-      .RegisterState<State3>(CompositeL3.State3, onSuccess: null);
+    var machine = GenerateStateMachineL3(new StateMachine<CompositeL3>(factory, null, isContextPersistent: contextIsPersistent));
 
     // Act
     await machine.RunAsync(CompositeL3.State1, cancellationToken: TestContext.CancellationToken);
@@ -286,5 +265,44 @@ public class CompositeStateTest : TestBase
       Assert.AreEqual(7, msgService.Counter2);
       Assert.AreEqual(11, msgService.Counter3);
     }
+  }
+
+  [TestMethod]
+  public async Task Level3_PreviousStateId_SuccessTestAsync()
+  {
+    // Assemble - Using DI for MessageService's counters
+    var services = new ServiceCollection()
+      .AddLogging(InlineTraceLogger(LogLevel.None))
+      .AddSingleton<IMessageService, MessageService>()
+      .BuildServiceProvider();
+
+    var msgService = services.GetRequiredService<IMessageService>();
+    Func<Type, object?> factory = t => ActivatorUtilities.CreateInstance(services, t);
+
+    var ctxProperties = new PropertyBag() { { ParameterType.TestExecutionOrder, true } };
+    var machine = GenerateStateMachineL3(new StateMachine<CompositeL3>(factory));
+
+    // Act
+    await machine.RunAsync(CompositeL3.State1, ctxProperties, null, TestContext.CancellationToken);
+
+    // Assert
+    Assert.IsNotNull(machine);
+    Assert.IsNull(machine.Context);
+  }
+
+  private StateMachine<CompositeL3> GenerateStateMachineL3(StateMachine<CompositeL3> machine)
+  {
+    machine
+      .RegisterState<State1>(CompositeL3.State1, CompositeL3.State2)
+      .RegisterComposite<State2>(CompositeL3.State2, initialChildStateId: CompositeL3.State2_Sub1, onSuccess: CompositeL3.State3)
+      .RegisterSubState<State2_Sub1>(CompositeL3.State2_Sub1, parentStateId: CompositeL3.State2, onSuccess: CompositeL3.State2_Sub2)
+      .RegisterSubComposite<State2_Sub2>(CompositeL3.State2_Sub2, parentStateId: CompositeL3.State2, initialChildStateId: CompositeL3.State2_Sub2_Sub1, onSuccess: CompositeL3.State2_Sub3)
+      .RegisterSubState<State2_Sub2_Sub1>(CompositeL3.State2_Sub2_Sub1, parentStateId: CompositeL3.State2_Sub2, onSuccess: CompositeL3.State2_Sub2_Sub2)
+      .RegisterSubState<State2_Sub2_Sub2>(CompositeL3.State2_Sub2_Sub2, parentStateId: CompositeL3.State2_Sub2, onSuccess: CompositeL3.State2_Sub2_Sub3)
+      .RegisterSubState<State2_Sub2_Sub3>(CompositeL3.State2_Sub2_Sub3, parentStateId: CompositeL3.State2_Sub2, onSuccess: null)
+      .RegisterSubState<State2_Sub3>(CompositeL3.State2_Sub3, parentStateId: CompositeL3.State2, onSuccess: null)
+      .RegisterState<State3>(CompositeL3.State3, onSuccess: null);
+
+    return machine;
   }
 }

--- a/source/Lite.StateMachine.Tests/StateTests/CompositeStateTest.cs
+++ b/source/Lite.StateMachine.Tests/StateTests/CompositeStateTest.cs
@@ -61,7 +61,7 @@ public class CompositeStateTest : TestBase
 
     // Ensure all states are hit
     var enums = Enum.GetValues<CompositeL1StateId>().Cast<CompositeL1StateId>();
-    Assert.AreEqual(enums.Count(), machine.States.Count());
+    Assert.HasCount(enums.Count(), machine.States);
     Assert.IsTrue(enums.All(k => machine.States.Contains(k)));
 
     // Ensure they're in order
@@ -89,7 +89,7 @@ public class CompositeStateTest : TestBase
 
     // Ensure all states are hit
     var enums = Enum.GetValues<CompositeL1StateId>().Cast<CompositeL1StateId>();
-    Assert.AreEqual(enums.Count(), machine.States.Count());
+    Assert.HasCount(enums.Count(), machine.States);
     Assert.IsTrue(enums.All(k => machine.States.Contains(k)));
 
     // Ensure they're in order
@@ -139,7 +139,7 @@ public class CompositeStateTest : TestBase
 
     // Ensure all states are hit
     var enums = Enum.GetValues<CompositeL1StateId>().Cast<CompositeL1StateId>();
-    Assert.AreEqual(enums.Count(), machine.States.Count());
+    Assert.HasCount(enums.Count(), machine.States);
     Assert.IsTrue(enums.All(k => machine.States.Contains(k)));
 
     // Ensure they're in order
@@ -166,7 +166,7 @@ public class CompositeStateTest : TestBase
 
     // Ensure all states are hit
     var enums = Enum.GetValues<CompositeL1StateId>().Cast<CompositeL1StateId>();
-    Assert.AreEqual(enums.Count(), machine.States.Count());
+    Assert.HasCount(enums.Count(), machine.States);
     Assert.IsTrue(enums.All(k => machine.States.Contains(k)));
 
     // Ensure they're in order
@@ -230,7 +230,7 @@ public class CompositeStateTest : TestBase
 
     // Ensure all states are registered
     var enums = Enum.GetValues<CompositeL3>().Cast<CompositeL3>();
-    Assert.AreEqual(enums.Count(), machine.States.Count());
+    Assert.HasCount(enums.Count(), machine.States);
     Assert.IsTrue(enums.All(stateId => machine.States.Contains(stateId)));
 
     // State Transition counter (9 states, 3 transitions)
@@ -290,7 +290,7 @@ public class CompositeStateTest : TestBase
     Assert.IsNull(machine.Context);
   }
 
-  private StateMachine<CompositeL3> GenerateStateMachineL3(StateMachine<CompositeL3> machine)
+  private static StateMachine<CompositeL3> GenerateStateMachineL3(StateMachine<CompositeL3> machine)
   {
     machine
       .RegisterState<State1>(CompositeL3.State1, CompositeL3.State2)

--- a/source/Lite.StateMachine.Tests/StateTests/CustomStateTests.cs
+++ b/source/Lite.StateMachine.Tests/StateTests/CustomStateTests.cs
@@ -94,8 +94,8 @@ public class CustomStateTests : TestBase
 
   [TestMethod]
   [DataRow(false, DisplayName = "Run State2_Sub3")]
-  [DataRow(true, DisplayName = "Skip State2_Sub3")]
-  public async Task Composite_Override_Executes_SuccessAsync(bool skipSubState3)
+  [DataRow(true, DisplayName = "Skip State2_Sub2")]
+  public async Task Composite_Override_Executes_SuccessAsync(bool skipSubState2)
   {
     // Assemble with Dependency Injection
     var services = new ServiceCollection()
@@ -110,7 +110,7 @@ public class CustomStateTests : TestBase
     var ctxProperties = new PropertyBag()
     {
       { ParameterType.Counter, 0 },
-      { ParameterType.TestExitEarly2, skipSubState3 },
+      { ParameterType.TestExitEarly2, skipSubState2 },
     };
 
     var machine = new StateMachine<CustomStateId>(factory, null, isContextPersistent: true);
@@ -130,7 +130,7 @@ public class CustomStateTests : TestBase
     Assert.IsNotNull(machine);
     Assert.IsNull(machine.Context);
 
-    Assert.AreEqual(skipSubState3 ? 2 : 3, msgService.Counter1, "State Counter1 failed.");
+    Assert.AreEqual(skipSubState2 ? 3 : 4, msgService.Counter1, "State Counter1 failed.");
     Assert.AreEqual(0, msgService.Counter2, "State2Dummy should never enter");
     Assert.AreEqual(1, msgService.Counter3, "Skip Substate Counter3 failed");
   }

--- a/source/Lite.StateMachine.Tests/TestData/ParameterType.cs
+++ b/source/Lite.StateMachine.Tests/TestData/ParameterType.cs
@@ -8,17 +8,20 @@ public enum ParameterType
   /// <summary>Generic counter.</summary>
   Counter,
 
-  /// <summary>Tests for DoNotAllowHungStatesTest.</summary>
-  HungStateAvoidance,
-
   /// <summary>Random test.</summary>
   KeyTest,
+
+  /// <summary>Test states executed in order using context.LastStateId or states in a different order.</summary>
+  TestExecutionOrder,
 
   /// <summary>Test triggers an early exit. Setting OnSuccess to NULL.</summary>
   TestExitEarly,
 
   /// <summary>Test triggers a 2nd early exit. Setting OnSuccess to NULL.</summary>
   TestExitEarly2,
+
+  /// <summary>Tests for DoNotAllowHungStatesTest.</summary>
+  TestHungStateAvoidance,
 
   /// <summary>Test trigger to go to an invalid state transition.</summary>
   TestUnregisteredTransition,

--- a/source/Lite.StateMachine.Tests/TestData/States/BasicStates.cs
+++ b/source/Lite.StateMachine.Tests/TestData/States/BasicStates.cs
@@ -8,9 +8,21 @@ namespace Lite.StateMachine.Tests.TestData.States;
 
 #pragma warning disable SA1649 // File name should match first type name
 #pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1124 // Do not use regions
 
 public class BasicState1() : IState<BasicStateId>
 {
+  #region Suppress CodeMaid Method Sorting
+
+  public Task OnEntering(Context<BasicStateId> context)
+  {
+    context.Parameters[ParameterType.Counter] = context.ParameterAsInt(ParameterType.Counter) + 1;
+    Console.WriteLine($"[BasicState1][OnEntering] {context.Parameters[ParameterType.Counter]}");
+    return Task.CompletedTask;
+  }
+
+  #endregion Suppress CodeMaid Method Sorting
+
   public async Task OnEnter(Context<BasicStateId> context)
   {
     // Some async work here...
@@ -19,13 +31,6 @@ public class BasicState1() : IState<BasicStateId>
     context.Parameters[ParameterType.Counter] = context.ParameterAsInt(ParameterType.Counter) + 1;
     context.NextState(Result.Success);
     Console.WriteLine($"[BasicState1][OnEnter] {context.Parameters[ParameterType.Counter]} => OK");
-  }
-
-  public Task OnEntering(Context<BasicStateId> context)
-  {
-    context.Parameters[ParameterType.Counter] = context.ParameterAsInt(ParameterType.Counter) + 1;
-    Console.WriteLine($"[BasicState1][OnEntering] {context.Parameters[ParameterType.Counter]}");
-    return Task.CompletedTask;
   }
 
   public Task OnExit(Context<BasicStateId> context)
@@ -38,23 +43,33 @@ public class BasicState1() : IState<BasicStateId>
 
 public class BasicState2() : IState<BasicStateId>
 {
-  public Task OnEnter(Context<BasicStateId> context)
-  {
-    context.Parameters[ParameterType.Counter] = context.ParameterAsInt(ParameterType.Counter) + 1;
-
-    // Only move to the next state if we are not testing hanging state avoidance
-    var testHangingState = context.ParameterAsBool(ParameterType.HungStateAvoidance);
-    if (!testHangingState)
-      context.NextState(Result.Success);
-
-    Console.WriteLine($"[BasicState2][OnEnter] {context.Parameters[ParameterType.Counter]} => OK");
-    return Task.CompletedTask;
-  }
+  #region Suppress CodeMaid Method Sorting
 
   public Task OnEntering(Context<BasicStateId> context)
   {
     context.Parameters[ParameterType.Counter] = context.ParameterAsInt(ParameterType.Counter) + 1;
     Console.WriteLine($"[BasicState2][OnEntering] {context.Parameters[ParameterType.Counter]}");
+    return Task.CompletedTask;
+  }
+
+  #endregion Suppress CodeMaid Method Sorting
+
+  public Task OnEnter(Context<BasicStateId> context)
+  {
+    context.Parameters[ParameterType.Counter] = context.ParameterAsInt(ParameterType.Counter) + 1;
+
+    // Assert origin of the previous state
+    if (context.ParameterAsBool(ParameterType.TestExecutionOrder))
+      Assert.AreEqual(BasicStateId.State1, context.PreviousStateId);
+    else
+      Assert.AreEqual(BasicStateId.State3, context.PreviousStateId);
+
+    // Only move to the next state if we are not testing hanging state avoidance
+    var testHangingState = context.ParameterAsBool(ParameterType.TestHungStateAvoidance);
+    if (!testHangingState)
+      context.NextState(Result.Success);
+
+    Console.WriteLine($"[BasicState2][OnEnter] {context.Parameters[ParameterType.Counter]} => OK");
     return Task.CompletedTask;
   }
 
@@ -68,19 +83,29 @@ public class BasicState2() : IState<BasicStateId>
 
 public class BasicState3() : IState<BasicStateId>
 {
-  public Task OnEnter(Context<BasicStateId> context)
-  {
-    context.Parameters[ParameterType.Counter] = context.ParameterAsInt(ParameterType.Counter) + 1;
-    context.Parameters[ParameterType.KeyTest] = MessageType.SuccessResponse;
-    context.NextState(Result.Success);
-    Console.WriteLine($"[BasicState3][OnEnter] {context.Parameters[ParameterType.Counter]}");
-    return Task.CompletedTask;
-  }
+  #region Suppress CodeMaid Method Sorting
 
   public Task OnEntering(Context<BasicStateId> context)
   {
     context.Parameters[ParameterType.Counter] = context.ParameterAsInt(ParameterType.Counter) + 1;
     Console.WriteLine($"[BasicState3][OnEntering] {context.Parameters[ParameterType.Counter]}");
+    return Task.CompletedTask;
+  }
+
+  #endregion Suppress CodeMaid Method Sorting
+
+  public Task OnEnter(Context<BasicStateId> context)
+  {
+    // Assert origin of the previous state
+    if (context.ParameterAsBool(ParameterType.TestExecutionOrder))
+      Assert.AreEqual(BasicStateId.State2, context.PreviousStateId);
+    else
+      Assert.AreEqual(BasicStateId.State1, context.PreviousStateId);
+
+    context.Parameters[ParameterType.Counter] = context.ParameterAsInt(ParameterType.Counter) + 1;
+    context.Parameters[ParameterType.KeyTest] = MessageType.SuccessResponse;
+    context.NextState(Result.Success);
+    Console.WriteLine($"[BasicState3][OnEnter] {context.Parameters[ParameterType.Counter]}");
     return Task.CompletedTask;
   }
 
@@ -92,5 +117,6 @@ public class BasicState3() : IState<BasicStateId>
   }
 }
 
+#pragma warning restore SA1124 // Do not use regions
 #pragma warning restore SA1649 // File name should match first type name
 #pragma warning restore SA1402 // File may only contain a single type

--- a/source/Lite.StateMachine.Tests/TestData/States/CompositeL3DiStates.cs
+++ b/source/Lite.StateMachine.Tests/TestData/States/CompositeL3DiStates.cs
@@ -33,6 +33,9 @@ public class State1(IMessageService msg, ILogger<State1> log)
 {
   public override Task OnEnter(Context<CompositeL3> context)
   {
+    if (context.ParameterAsBool(ParameterType.TestExecutionOrder))
+      Assert.IsNull(context.PreviousStateId);
+
     context.Parameters.Add(context.CurrentStateId.ToString(), Guid.NewGuid());
     MessageService.AddMessage($"[Keys-{context.CurrentStateId}]: {string.Join(",", context.Parameters.Keys)}");
     return base.OnEnter(context);
@@ -56,6 +59,9 @@ public class State2(IMessageService msg, ILogger<State2> log)
 
   public override Task OnEnter(Context<CompositeL3> context)
   {
+    if (context.ParameterAsBool(ParameterType.TestExecutionOrder))
+      Assert.AreEqual(CompositeL3.State1, context.PreviousStateId);
+
     // Demonstrate temporary parameter that will be discarded after State2's OnExit
     context.Parameters.Add($"{context.CurrentStateId}!TEMP", Guid.NewGuid());
     return base.OnEnter(context);
@@ -72,7 +78,16 @@ public class State2(IMessageService msg, ILogger<State2> log)
 
 /// <summary>Sublevel-2: State.<summary>
 public class State2_Sub1(IMessageService msg, ILogger<State2_Sub1> log)
-  : CommonDiStateBase<State2_Sub1, CompositeL3>(msg, log);
+  : CommonDiStateBase<State2_Sub1, CompositeL3>(msg, log)
+{
+  public override Task OnEnter(Context<CompositeL3> context)
+  {
+    if (context.ParameterAsBool(ParameterType.TestExecutionOrder))
+      Assert.IsNull(context.PreviousStateId);
+
+    return base.OnEnter(context);
+  }
+}
 
 /// <summary>Sublevel-2: Composite.</summary>
 public class State2_Sub2(IMessageService msg, ILogger<State2_Sub2> log)
@@ -91,6 +106,9 @@ public class State2_Sub2(IMessageService msg, ILogger<State2_Sub2> log)
 
   public override Task OnEnter(Context<CompositeL3> context)
   {
+    if (context.ParameterAsBool(ParameterType.TestExecutionOrder))
+      Assert.AreEqual(CompositeL3.State2_Sub1, context.PreviousStateId);
+
     // Demonstrate temporary parameter that will be discarded after State2_Sub2's OnExit
     context.Parameters.Add($"{context.CurrentStateId}!TEMP", Guid.NewGuid());
     return base.OnEnter(context);
@@ -106,7 +124,16 @@ public class State2_Sub2(IMessageService msg, ILogger<State2_Sub2> log)
 
 /// <summary>Sublevel-3: State.</summary>
 public class State2_Sub2_Sub1(IMessageService msg, ILogger<State2_Sub2_Sub1> log)
-  : CommonDiStateBase<State2_Sub2_Sub1, CompositeL3>(msg, log);
+  : CommonDiStateBase<State2_Sub2_Sub1, CompositeL3>(msg, log)
+{
+  public override Task OnEnter(Context<CompositeL3> context)
+  {
+    if (context.ParameterAsBool(ParameterType.TestExecutionOrder))
+      Assert.IsNull(context.PreviousStateId);
+
+    return base.OnEnter(context);
+  }
+}
 
 /// <summary>Sublevel-3: State.</summary>
 public class State2_Sub2_Sub2(IMessageService msg, ILogger<State2_Sub2_Sub2> log)
@@ -114,7 +141,16 @@ public class State2_Sub2_Sub2(IMessageService msg, ILogger<State2_Sub2_Sub2> log
 
 /// <summary>Sublevel-3: Last State.</summary>
 public class State2_Sub2_Sub3(IMessageService msg, ILogger<State2_Sub2_Sub3> log)
-  : CommonDiStateBase<State2_Sub2_Sub3, CompositeL3>(msg, log);
+  : CommonDiStateBase<State2_Sub2_Sub3, CompositeL3>(msg, log)
+{
+  public override Task OnEnter(Context<CompositeL3> context)
+  {
+    if (context.ParameterAsBool(ParameterType.TestExecutionOrder))
+      Assert.AreEqual(CompositeL3.State2_Sub2_Sub2, context.PreviousStateId);
+
+    return base.OnEnter(context);
+  }
+}
 
 /// <summary>Sublevel-2: Last State.</summary>
 public class State2_Sub3(IMessageService msg, ILogger<State2_Sub3> log)
@@ -122,6 +158,9 @@ public class State2_Sub3(IMessageService msg, ILogger<State2_Sub3> log)
 {
   public override Task OnEnter(Context<CompositeL3> context)
   {
+    if (context.ParameterAsBool(ParameterType.TestExecutionOrder))
+      Assert.AreEqual(CompositeL3.State2_Sub2, context.PreviousStateId);
+
     context.Parameters.Add(context.CurrentStateId.ToString(), Guid.NewGuid());
     MessageService.AddMessage($"[Keys-{context.CurrentStateId}]: {string.Join(",", context.Parameters.Keys)}");
     return base.OnEnter(context);

--- a/source/Lite.StateMachine/Context.cs
+++ b/source/Lite.StateMachine/Context.cs
@@ -47,11 +47,11 @@ public sealed class Context<TStateId>
   /// <summary>Gets result emitted by the last child state (for composite parents only).</summary>
   public Result? LastChildResult { get; }
 
-  /////// <summary>Gets the previous state's enum value.</summary>
-  ////public TStateId PreviousState { get; internal set; }
-
   /// <summary>Gets or sets an arbitrary parameter provided by caller to the current action.</summary>
   public PropertyBag Parameters { get; set; } = [];
+
+  /// <summary>Gets the previous state's enum value.</summary>
+  public TStateId? PreviousStateId { get; internal set; }
 
   /// <summary>Signal the machine to move forward (only once per state entry).</summary>
   /// <param name="result">Result to pass to the next state.</param>

--- a/source/Lite.StateMachine/StateRegistration.cs
+++ b/source/Lite.StateMachine/StateRegistration.cs
@@ -32,10 +32,9 @@ internal sealed class StateRegistration<TStateId>
   /// <summary>Gets the sub-state's parent State Id (optional).</summary>
   public TStateId? ParentId { get; init; }
 
+  /// <summary>Gets or sets the Previous <typeparamref name="TStateId"/> we transitioned from.</summary>
+  public TStateId? PreviousStateId { get; set; }
+
   /// <summary>Gets the State Id, used by ExportUml for <see cref="RegisterState{TStateClass}(TStateId, TStateId?, TStateId?, TStateId?, Action{StateMachine{TStateId}}?)"./> .</summary>
   public TStateId StateId { get; init; }
-
-  //// INFO: Though dict lookup is more flexible, properties are faster. Leaving this here for reference.
-  /////// <summary>Gets the state result transitions OnSuccess, OnError, OnFailure.</summary>
-  ////public Dictionary<Result, TStateId?> Transitions { get; } = new();
 }

--- a/source/Sample.Basics/States/DemoMachine.cs
+++ b/source/Sample.Basics/States/DemoMachine.cs
@@ -19,7 +19,8 @@ public static class DemoMachine
   public static async Task RunAsync(bool logOutput = true)
   {
     var counter = 0;
-    var ctxProperties = new PropertyBag() {
+    var ctxProperties = new PropertyBag()
+    {
       { ParameterType.Counter, counter },
       { ParameterType.LogOutput, logOutput },
     };


### PR DESCRIPTION
## Details

Add back the ability to get the `PreviousStateId` from the `Context`

* `NULL` when initial top-level or initial substate.
* `TStateId` when a subsequent state

## Linked To Issue/Feature

* #77
