### PR TITLE
Initialize Context on construction and Test for Cancelling out of StateMachine Process

### DIFF
--- a/source/Lite.StateMachine.Tests/StateTests/BasicStateTests.cs
+++ b/source/Lite.StateMachine.Tests/StateTests/BasicStateTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Lite.StateMachine.Tests.TestData;
 using Lite.StateMachine.Tests.TestData.States;
@@ -10,10 +11,8 @@ using Lite.StateMachine.Tests.TestData.States;
 namespace Lite.StateMachine.Tests.StateTests;
 
 [TestClass]
-public class BasicStateTests
+public class BasicStateTests : TestBase
 {
-  public TestContext TestContext { get; set; }
-
   /// <summary>Standard synchronous state registration exiting to completion.</summary>
   [TestMethod]
   public void Basic_RegisterState_Executes123_SuccessTest()
@@ -35,8 +34,9 @@ public class BasicStateTests
     task.GetAwaiter().GetResult();
 
     // Assert Results
-    Assert.IsNotNull(machine);
-    Assert.IsNull(machine.Context);
+    AssertMachineNotNull(machine);
+
+    Assert.AreEqual(0, machine.Context.Parameters.Count);
 
     // Ensure all states are registered
     var enums = Enum.GetValues<BasicStateId>().Cast<BasicStateId>();
@@ -68,8 +68,7 @@ public class BasicStateTests
     await machine.RunAsync(BasicStateId.State1, ctxProperties);
 
     // Assert Results
-    Assert.IsNotNull(machine);
-    Assert.IsNull(machine.Context);
+    AssertMachineNotNull(machine);
 
     // Ensure all states are registered
     var enums = Enum.GetValues<BasicStateId>().Cast<BasicStateId>();
@@ -94,8 +93,7 @@ public class BasicStateTests
     await machine.RunAsync(BasicStateId.State1, ctxProperties);
 
     // Assert Results
-    Assert.IsNotNull(machine);
-    Assert.IsNull(machine.Context);
+    AssertMachineNotNull(machine);
 
     // Ensure all states are registered
     var enums = Enum.GetValues<BasicStateId>().Cast<BasicStateId>();
@@ -126,8 +124,7 @@ public class BasicStateTests
       .RunAsync(BasicStateId.State1, ctxProperties, cancellationToken: TestContext.CancellationToken);
 
     // Assert Results
-    Assert.IsNotNull(machine);
-    Assert.IsNull(machine.Context);
+    AssertMachineNotNull(machine);
 
     // Ensure all states are registered
     var enums = Enum.GetValues<BasicStateId>().Cast<BasicStateId>();
@@ -190,8 +187,7 @@ public class BasicStateTests
     await machine.RunAsync(BasicStateId.State1, ctxProperties);
 
     // Assert Results
-    Assert.IsNotNull(machine);
-    Assert.IsNull(machine.Context);
+    AssertMachineNotNull(machine);
 
     // Ensure all states are registered
     var enums = Enum.GetValues<BasicStateId>().Cast<BasicStateId>();
@@ -205,8 +201,6 @@ public class BasicStateTests
   [Ignore("vNext - Currently StateMachine destroys context after run completes.")]
   public async Task RegisterState_ReturnsContext_SuccessTestAsync()
   {
-    const string TestValue = "success";
-
     // Assemble
     var ctxProperties = new PropertyBag()
     {
@@ -224,15 +218,14 @@ public class BasicStateTests
     await task;   // Non async method: task.GetAwaiter().GetResult();
 
     // Assert Results
-    Assert.IsNotNull(machine);
-    Assert.IsNotNull(machine.Context);
+    AssertMachineNotNull(machine);
 
     var ctxFinalParams = machine.Context.Parameters;
     Assert.IsNotNull(ctxFinalParams);
-    Assert.AreEqual(TestValue, ctxFinalParams[ParameterType.KeyTest]);
+    Assert.AreNotEqual(0, ctxFinalParams.Count);
 
     // NOTE: This should be 9 because each state has 3 hooks that increment the counter
     // TODO (2025-12-22 DS): Fix last state not calling OnExit.
-    Assert.AreEqual(9, ctxFinalParams[ParameterType.Counter]);
+    ////Assert.AreEqual(9, ctxFinalParams[ParameterType.Counter]);
   }
 }

--- a/source/Lite.StateMachine.Tests/StateTests/CompositeStateTest.cs
+++ b/source/Lite.StateMachine.Tests/StateTests/CompositeStateTest.cs
@@ -54,8 +54,7 @@ public class CompositeStateTest : TestBase
     Console.WriteLine(umlBasic);
 
     // Assert
-    Assert.IsNotNull(machine);
-    Assert.IsNull(machine.Context);
+    AssertMachineNotNull(machine);
 
     // Ensure all states are hit
     var enums = Enum.GetValues<CompositeL1StateId>().Cast<CompositeL1StateId>();
@@ -82,8 +81,7 @@ public class CompositeStateTest : TestBase
     await machine.RunAsync(CompositeL1StateId.State1);
 
     // Assert
-    Assert.IsNotNull(machine);
-    Assert.IsNull(machine.Context);
+    AssertMachineNotNull(machine);
 
     // Ensure all states are hit
     var enums = Enum.GetValues<CompositeL1StateId>().Cast<CompositeL1StateId>();
@@ -132,8 +130,7 @@ public class CompositeStateTest : TestBase
       .RunAsync(CompositeL1StateId.State1, cancellationToken: TestContext.CancellationToken);
 
     // Assert
-    Assert.IsNotNull(machine);
-    Assert.IsNull(machine.Context);
+    AssertMachineNotNull(machine);
 
     // Ensure all states are hit
     var enums = Enum.GetValues<CompositeL1StateId>().Cast<CompositeL1StateId>();
@@ -159,8 +156,7 @@ public class CompositeStateTest : TestBase
       .GetResult();
 
     // Assert
-    Assert.IsNotNull(machine);
-    Assert.IsNull(machine.Context);
+    AssertMachineNotNull(machine);
 
     // Ensure all states are hit
     var enums = Enum.GetValues<CompositeL1StateId>().Cast<CompositeL1StateId>();
@@ -223,8 +219,7 @@ public class CompositeStateTest : TestBase
     await machine.RunAsync(CompositeL3.State1, cancellationToken: TestContext.CancellationToken);
 
     // Assert
-    Assert.IsNotNull(machine);
-    Assert.IsNull(machine.Context);
+    AssertMachineNotNull(machine);
 
     // Ensure all states are registered
     var enums = Enum.GetValues<CompositeL3>().Cast<CompositeL3>();
@@ -284,8 +279,7 @@ public class CompositeStateTest : TestBase
     await machine.RunAsync(CompositeL3.State1, ctxProperties, null, TestContext.CancellationToken);
 
     // Assert
-    Assert.IsNotNull(machine);
-    Assert.IsNull(machine.Context);
+    AssertMachineNotNull(machine);
   }
 
   private static StateMachine<CompositeL3> GenerateStateMachineL3(StateMachine<CompositeL3> machine)

--- a/source/Lite.StateMachine.Tests/StateTests/ContextTests.cs
+++ b/source/Lite.StateMachine.Tests/StateTests/ContextTests.cs
@@ -9,7 +9,7 @@ using Lite.StateMachine.Tests.TestData.States;
 namespace Lite.StateMachine.Tests.StateTests;
 
 [TestClass]
-public class ContextTests
+public class ContextTests : TestBase
 {
   public const string ParameterCounter = "Counter";
   public const string ParameterKeyTest = "TestKey";
@@ -29,8 +29,6 @@ public class ContextTests
     Param3,
   }
 
-  public TestContext TestContext { get; set; }
-
   /// <summary>Standard synchronous state registration exiting to completion.</summary>
   [TestMethod]
   public void Basic_RegisterState_Executes123_SuccessTest()
@@ -48,8 +46,7 @@ public class ContextTests
     task.GetAwaiter().GetResult();
 
     // Assert Results
-    Assert.IsNotNull(machine);
-    Assert.IsNull(machine.Context);
+    AssertMachineNotNull(machine);
 
     // Ensure all states are registered
     var enums = Enum.GetValues<CtxStateId>().Cast<CtxStateId>();

--- a/source/Lite.StateMachine.Tests/StateTests/CustomStateTests.cs
+++ b/source/Lite.StateMachine.Tests/StateTests/CustomStateTests.cs
@@ -45,8 +45,7 @@ public class CustomStateTests : TestBase
     await machine.RunAsync(CustomStateId.State1, ctxProperties, cancellationToken: TestContext.CancellationToken);
 
     // Assert Results
-    Assert.IsNotNull(machine);
-    Assert.IsNull(machine.Context);
+    AssertMachineNotNull(machine);
 
     Assert.AreEqual(1, msgService.Counter1);
     Assert.AreEqual(0, msgService.Counter2, "State2Dummy should never enter");
@@ -83,8 +82,7 @@ public class CustomStateTests : TestBase
       => machine.RunAsync(CustomStateId.State1, ctxProperties, null, TestContext.CancellationToken));
 
     // Assert Results
-    Assert.IsNotNull(machine);
-    Assert.IsNull(machine.Context);
+    AssertMachineNotNull(machine);
 
     Assert.AreEqual(0, msgService.Counter1);
     Assert.AreEqual(0, msgService.Counter2, "State2Dummy should never enter");
@@ -125,8 +123,7 @@ public class CustomStateTests : TestBase
     await machine.RunAsync(CustomStateId.State1, ctxProperties, cancellationToken: TestContext.CancellationToken);
 
     // Assert Results
-    Assert.IsNotNull(machine);
-    Assert.IsNull(machine.Context);
+    AssertMachineNotNull(machine);
 
     Assert.AreEqual(skipSubState2 ? 3 : 4, msgService.Counter1, "State Counter1 failed.");
     Assert.AreEqual(0, msgService.Counter2, "State2Dummy should never enter");

--- a/source/Lite.StateMachine.Tests/StateTests/DiMsTests.cs
+++ b/source/Lite.StateMachine.Tests/StateTests/DiMsTests.cs
@@ -18,7 +18,7 @@ namespace Lite.StateMachine.Tests.StateTests;
 /// <summary>Microsoft Dependency Injection Tests.</summary>
 [TestClass]
 [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1124:Do not use regions", Justification = "Allowed for this test class")]
-public class DiMsTests
+public class DiMsTests : TestBase
 {
   [TestMethod]
   public async Task Basic_FlatStates_SuccessTestAsync()
@@ -44,8 +44,7 @@ public class DiMsTests
     var result = await machine.RunAsync(BasicStateId.State1);
 
     Assert.IsNotNull(result);
-    Assert.IsNotNull(machine);
-    Assert.IsNull(machine.Context);
+    AssertMachineNotNull(machine);
 
     var msgService = services.GetRequiredService<IMessageService>();
     Assert.AreEqual(9, msgService.Counter1, "Message service should have 9 from the 3 states.");
@@ -142,8 +141,7 @@ public class DiMsTests
     var result = await machine.RunAsync(BasicStateId.State1);
 
     Assert.IsNotNull(result);
-    Assert.IsNotNull(machine);
-    Assert.IsNull(machine.Context);
+    AssertMachineNotNull(machine);
 
     // Ensure all states are registered
     var enums = Enum.GetValues<BasicStateId>().Cast<BasicStateId>();
@@ -276,6 +274,9 @@ public class DiMsTests
     await machine.RunAsync(CompositeMsgStateId.Entry, null, null, CancellationToken.None);
 
     Console.WriteLine("MS.DI workflow finished.");
+
+    // Assert
+    AssertMachineNotNull(machine);
 
     Assert.AreEqual(2, msgService.Counter2);
     Assert.AreEqual(42, msgService.Counter1);

--- a/source/Lite.StateMachine.Tests/StateTests/TestBase.cs
+++ b/source/Lite.StateMachine.Tests/StateTests/TestBase.cs
@@ -9,7 +9,14 @@ namespace Lite.StateMachine.Tests.StateTests;
 
 public class TestBase
 {
-  public TestContext TestContext { get; set; }
+  public required TestContext TestContext { get; set; }
+
+  protected static void AssertMachineNotNull<T>(Lite.StateMachine.StateMachine<T> machine)
+    where T : struct, Enum
+  {
+    Assert.IsNotNull(machine);
+    Assert.IsNotNull(machine.Context);
+  }
 
   /// <summary>ILogger Helper for generating clean in-line logs.</summary>
   /// <param name="logLevel">Log level (Default: Trace).</param>

--- a/source/Lite.StateMachine.Tests/TestData/Models/CustomCommands.cs
+++ b/source/Lite.StateMachine.Tests/TestData/Models/CustomCommands.cs
@@ -9,6 +9,19 @@ namespace Lite.StateMachine.Tests.TestData.Models;
 /// <summary>Signifies it's one of our event packets.</summary>
 public interface ICustomCommand;
 
+public class CancelCommand : ICustomCommand
+{
+  public int Counter { get; set; }
+}
+
+public class CancelResponse : ICustomCommand;
+
+/// <summary>Sample command response received by state machine.</summary>
+public class CloseResponse : ICustomCommand
+{
+  public int Counter { get; set; } = 0;
+}
+
 /// <summary>Sample command sent by state machine.</summary>
 public class UnlockCommand : ICustomCommand
 {
@@ -17,12 +30,6 @@ public class UnlockCommand : ICustomCommand
 
 /// <summary>Sample command response received by state machine.</summary>
 public class UnlockResponse : ICustomCommand
-{
-  public int Counter { get; set; } = 0;
-}
-
-/// <summary>Sample command response received by state machine.</summary>
-public class CloseResponse : ICustomCommand
 {
   public int Counter { get; set; } = 0;
 }

--- a/source/Lite.StateMachine/StateMachine.cs
+++ b/source/Lite.StateMachine/StateMachine.cs
@@ -65,7 +65,8 @@ public sealed partial class StateMachine<TStateId> : IStateMachine<TStateId>
   }
 
   /// <inheritdoc/>
-  public Context<TStateId> Context { get; private set; } = default!;
+  public Context<TStateId> Context { get; private set; } = new Context<TStateId>(default, default, default!, null);
+  ////public Context<TStateId> Context { get; private set; } = default!;
 
   /// <inheritdoc/>
   public int DefaultCommandTimeoutMs { get; set; } = 3000;
@@ -209,6 +210,9 @@ public sealed partial class StateMachine<TStateId> : IStateMachine<TStateId>
     TStateId? prevStateId = null;
     var currentStateId = initialStateId;
 
+    // TBD
+    ////Context = new Context<TStateId>(currentStateId, default, default!, null);
+
     while (!cancellationToken.IsCancellationRequested)
     {
       var reg = GetRegistration(currentStateId);
@@ -222,11 +226,15 @@ public sealed partial class StateMachine<TStateId> : IStateMachine<TStateId>
       ////  Errors = errorStack ?? [],
       ////};
 
+      ////Context.Parameters = parameterStack ?? [];
+      ////Context.Errors = errorStack ?? [];
+
       parameterStack ??= [];
       errorStack ??= [];
 
       // Run any state (composite or leaf) recursively.
       var result = await RunAnyStateRecursiveAsync(reg, parameterStack, errorStack, cancellationToken).ConfigureAwait(false);
+      ////var result = await RunAnyStateRecursiveAsync(reg, cancellationToken).ConfigureAwait(false);
       if (result is null)
         break;
 
@@ -292,11 +300,12 @@ public sealed partial class StateMachine<TStateId> : IStateMachine<TStateId>
     CancellationToken ct)
   {
     // Ensure we always operate on non-null, shared bags
-    parameters ??= [];
-    errors ??= [];
+    ////parameters ??= [];
+    ////errors ??= [];
 
     // Run Normal or Command State
     if (!reg.IsCompositeParent)
+      ////return await RunLeafAsync(reg, ct).ConfigureAwait(false);
       return await RunLeafAsync(reg, parameters, errors, ct).ConfigureAwait(false);
 
     // Composite States


### PR DESCRIPTION
## Details

1. Added test for Canceling StateMachine while running using infinite loop states.
2. Context is not null after exiting; but it is not fully initialized either

## Linked To Issue/Feature

* #88