### PR TITLE
#88 - Improve Context Memory Allocation; Increasing Throughput

### DIFF
--- a/readme-nuget.md
+++ b/readme-nuget.md
@@ -8,9 +8,9 @@ The Lite State Machine is designed for vertical scaling. Meaning, it can be used
 
 ||
 |-|
-| Copyright 2021-2025 Xeno Innovations, Inc. (_dba, Suess Labs_) |
+| Copyright 2021-2026 Xeno Innovations, Inc. (_DBA:, Suess Labs_) |
 | Created by: Damian Suess |
-| Date: 2021-06-07 |
+| Date: 2021-06-07 (_inception 2016_) |
 
 ## Package Releases
 
@@ -92,10 +92,9 @@ var uml = machine.ExportUml(includeSubmachines: true);
 ```cs
 using Lite.StateMachine;
 
-var ctxProperties = new PropertyBag() { { "CounterKey", 0 } };
-
 // Note the use of generics '<TStateClass>' to strongly-type the state machine
 var machine = new StateMachine<CompositeL1StateId>()
+  .AddContext(new() { { ParameterType.Counter, 999 } });
   .RegisterState<Composite_State1>(CompositeL1StateId.State1, CompositeL1StateId.State2)
 
   .RegisterComposite<Composite_State2>(
@@ -126,6 +125,9 @@ public class Composite_State1() : BaseState
 {
   public override Task OnEnter(Context<CompositeL1StateId> context)
   {
+    var cnt = context.ParameterAsInt(ParameterType.Counter);
+    var blank = context.ParameterAsBool(ParameterType.DummyBool);
+
     context.NextState(Result.Ok);
     return Task.CompletedTask;
   }
@@ -152,7 +154,9 @@ public class Composite_State2_Sub1() : BaseState
 {
   public override Task OnEnter(Context<CompositeL1StateId> context)
   {
-    context.Parameters.Add("ParameterSubStateEntered", SUCCESS);
+    // Safely add/update key-value in Context
+    context.Parameters.SafeAdd("StringBasedParamKey", SUCCESS);
+
     context.NextState(Result.Ok);
     return Task.CompletedTask;
   }

--- a/readme.md
+++ b/readme.md
@@ -10,9 +10,9 @@ The Lite State Machine is designed for vertical scaling. Meaning, it can be used
 
 ||
 |-|
-| Copyright 2021-2025 Xeno Innovations, Inc. (_dba, Suess Labs_) |
+| Copyright 2021-2026 Xeno Innovations, Inc. (_DBA: Suess Labs_) |
 | Created by: Damian Suess |
-| Date: 2021-06-07 |
+| Date: 2021-06-07 (_inception 2016_) |
 
 ## Package Releases
 
@@ -94,10 +94,9 @@ var uml = machine.ExportUml(includeSubmachines: true);
 ```cs
 using Lite.StateMachine;
 
-var ctxProperties = new PropertyBag() { { "CounterKey", 0 } };
-
 // Note the use of generics '<TStateClass>' to strongly-type the state machine
 var machine = new StateMachine<CompositeL1StateId>()
+  .AddContext(new() { { ParameterType.Counter, 999 } });
   .RegisterState<Composite_State1>(CompositeL1StateId.State1, CompositeL1StateId.State2)
 
   .RegisterComposite<Composite_State2>(
@@ -128,6 +127,9 @@ public class Composite_State1() : BaseState
 {
   public override Task OnEnter(Context<CompositeL1StateId> context)
   {
+    var cnt = context.ParameterAsInt(ParameterType.Counter);
+    var blank = context.ParameterAsBool(ParameterType.DummyBool);
+
     context.NextState(Result.Ok);
     return Task.CompletedTask;
   }
@@ -154,7 +156,9 @@ public class Composite_State2_Sub1() : BaseState
 {
   public override Task OnEnter(Context<CompositeL1StateId> context)
   {
-    context.Parameters.Add("ParameterSubStateEntered", SUCCESS);
+    // Safely add/update key-value in Context
+    context.Parameters.SafeAdd("StringBasedParamKey", SUCCESS);
+
     context.NextState(Result.Ok);
     return Task.CompletedTask;
   }

--- a/source/Lite.StateMachine.BenchmarkTests/BasicStateBenchmarks.cs
+++ b/source/Lite.StateMachine.BenchmarkTests/BasicStateBenchmarks.cs
@@ -33,26 +33,26 @@ public class BasicStateBenchmarks
   public async Task BasicStatesRunsAsync()
   {
     var maxCounter = CyclesBeforeExit;
-    PropertyBag parameters = new()
+    _machine.Context.Parameters = new()
     {
       { ParameterType.MaxCounter, maxCounter },
       { ParameterType.Counter, 0 },
     };
 
-    await _machine.RunAsync(BasicStateId.State1, parameters);
+    await _machine.RunAsync(BasicStateId.State1);
   }
 
   [Benchmark]
   public void BasicStatesRunsSync()
   {
     var maxCounter = CyclesBeforeExit;
-    PropertyBag parameters = new()
+    _machine.Context.Parameters = new()
     {
       { ParameterType.MaxCounter, maxCounter },
       { ParameterType.Counter, 0 },
     };
 
-    _machine.RunAsync(BasicStateId.State1, parameters)
+    _machine.RunAsync(BasicStateId.State1)
             .GetAwaiter()
             .GetResult();
   }

--- a/source/Lite.StateMachine.Tests/StateTests/CommandStateTests.cs
+++ b/source/Lite.StateMachine.Tests/StateTests/CommandStateTests.cs
@@ -46,6 +46,7 @@ public class CommandStateTests : TestBase
     };
 
     machine
+      .AddContext(ctxProperties)
       .RegisterState<State1>(StateId.State1, StateId.State2)
       .RegisterComposite<State2>(StateId.State2, initialChildStateId: StateId.State2_Sub1, onSuccess: StateId.State3)
       .RegisterSubState<State2_Sub1>(StateId.State2_Sub1, parentStateId: StateId.State2, onSuccess: StateId.State2_Sub2)
@@ -81,7 +82,7 @@ public class CommandStateTests : TestBase
     });
 
     // Act - Start your engine!
-    await machine.RunAsync(StateId.State1, ctxProperties, null, TestContext.CancellationToken);
+    await machine.RunAsync(StateId.State1, TestContext.CancellationToken);
 
     // Assert Results
     AssertMachineNotNull(machine);
@@ -131,7 +132,7 @@ public class CommandStateTests : TestBase
       events.Publish(new CancelResponse());
     });
 
-    var result = await machine.RunAsync(StateId.State1, null, null, cts.Token);
+    var result = await machine.RunAsync(StateId.State1, cts.Token);
 
     // Assert
     Assert.IsNotNull(result);

--- a/source/Lite.StateMachine.Tests/StateTests/CompositeStateTest.cs
+++ b/source/Lite.StateMachine.Tests/StateTests/CompositeStateTest.cs
@@ -274,9 +274,10 @@ public class CompositeStateTest : TestBase
 
     var ctxProperties = new PropertyBag() { { ParameterType.TestExecutionOrder, true } };
     var machine = GenerateStateMachineL3(new StateMachine<CompositeL3>(factory));
+    machine.AddContext(ctxProperties);
 
     // Act
-    await machine.RunAsync(CompositeL3.State1, ctxProperties, null, TestContext.CancellationToken);
+    await machine.RunAsync(CompositeL3.State1, TestContext.CancellationToken);
 
     // Assert
     AssertMachineNotNull(machine);

--- a/source/Lite.StateMachine.Tests/StateTests/ContextTests.cs
+++ b/source/Lite.StateMachine.Tests/StateTests/ContextTests.cs
@@ -40,9 +40,10 @@ public class ContextTests : TestBase
     machine.RegisterState<CtxState1>(CtxStateId.State1, CtxStateId.State2);
     machine.RegisterState<CtxState2>(CtxStateId.State2, CtxStateId.State3);
     machine.RegisterState<CtxState3>(CtxStateId.State3);
+    machine.AddContext(ctxProperties);
 
     // Act - Non async Start your engine!
-    var task = machine.RunAsync(CtxStateId.State1, ctxProperties);
+    var task = machine.RunAsync(CtxStateId.State1);
     task.GetAwaiter().GetResult();
 
     // Assert Results

--- a/source/Lite.StateMachine.Tests/StateTests/ContextTests.cs
+++ b/source/Lite.StateMachine.Tests/StateTests/ContextTests.cs
@@ -34,13 +34,11 @@ public class ContextTests : TestBase
   public void Basic_RegisterState_Executes123_SuccessTest()
   {
     // Assemble
-    var ctxProperties = new PropertyBag() { { "KeyString_ValueInt", 99 } };
-
     var machine = new StateMachine<CtxStateId>();
     machine.RegisterState<CtxState1>(CtxStateId.State1, CtxStateId.State2);
     machine.RegisterState<CtxState2>(CtxStateId.State2, CtxStateId.State3);
     machine.RegisterState<CtxState3>(CtxStateId.State3);
-    machine.AddContext(ctxProperties);
+    machine.AddContext(new() { { "KeyString_ValueInt", 99 } });
 
     // Act - Non async Start your engine!
     var task = machine.RunAsync(CtxStateId.State1);

--- a/source/Lite.StateMachine.Tests/StateTests/CustomStateTests.cs
+++ b/source/Lite.StateMachine.Tests/StateTests/CustomStateTests.cs
@@ -29,20 +29,19 @@ public class CustomStateTests : TestBase
     var msgService = services.GetRequiredService<IMessageService>();
     Func<Type, object?> factory = t => ActivatorUtilities.CreateInstance(services, t);
 
-    var ctxProperties = new PropertyBag()
-    {
-      { ParameterType.Counter, 0 },
-      { ParameterType.TestExitEarly, skipState3 },
-    };
-
     var machine = new StateMachine<CustomStateId>(factory, null, isContextPersistent: true);
     machine.RegisterState<State1>(CustomStateId.State1, CustomStateId.State2_Dummy);
     machine.RegisterState<State2Dummy>(CustomStateId.State2_Dummy, CustomStateId.State3);
     machine.RegisterState<State2Success>(CustomStateId.State2_Success, CustomStateId.State3);
     machine.RegisterState<State3>(CustomStateId.State3);
+    machine.AddContext(new()
+    {
+      { ParameterType.Counter, 0 },
+      { ParameterType.TestExitEarly, skipState3 },
+    });
 
     // Act - Start your engine!
-    await machine.RunAsync(CustomStateId.State1, ctxProperties, cancellationToken: TestContext.CancellationToken);
+    await machine.RunAsync(CustomStateId.State1, cancellationToken: TestContext.CancellationToken);
 
     // Assert Results
     AssertMachineNotNull(machine);
@@ -72,6 +71,7 @@ public class CustomStateTests : TestBase
     };
 
     var machine = new StateMachine<CustomStateId>(factory, null, isContextPersistent: true);
+    machine.AddContext(ctxProperties);
     machine.RegisterState<State1>(CustomStateId.State1, CustomStateId.State2_Dummy);
     machine.RegisterState<State2Dummy>(CustomStateId.State2_Dummy, CustomStateId.State3);
     machine.RegisterState<State2Success>(CustomStateId.State2_Success, CustomStateId.State3);
@@ -79,7 +79,7 @@ public class CustomStateTests : TestBase
 
     // Act - Start your engine!
     await Assert.ThrowsExactlyAsync<UnregisteredStateTransitionException>(()
-      => machine.RunAsync(CustomStateId.State1, ctxProperties, null, TestContext.CancellationToken));
+      => machine.RunAsync(CustomStateId.State1, TestContext.CancellationToken));
 
     // Assert Results
     AssertMachineNotNull(machine);
@@ -110,7 +110,7 @@ public class CustomStateTests : TestBase
     };
 
     var machine = new StateMachine<CustomStateId>(factory, null, isContextPersistent: true);
-
+    machine.AddContext(ctxProperties);
     machine.RegisterState<State1>(CustomStateId.State1, CustomStateId.State2_Dummy);
     machine.RegisterState<State2Dummy>(CustomStateId.State2_Dummy, CustomStateId.State3);
     machine.RegisterComposite<State2Success>(CustomStateId.State2_Success, CustomStateId.State2_Sub1, CustomStateId.State3);
@@ -120,7 +120,7 @@ public class CustomStateTests : TestBase
     machine.RegisterState<State3>(CustomStateId.State3);
 
     // Act - Start your engine!
-    await machine.RunAsync(CustomStateId.State1, ctxProperties, cancellationToken: TestContext.CancellationToken);
+    await machine.RunAsync(CustomStateId.State1, cancellationToken: TestContext.CancellationToken);
 
     // Assert Results
     AssertMachineNotNull(machine);

--- a/source/Lite.StateMachine.Tests/StateTests/DiMsTests.cs
+++ b/source/Lite.StateMachine.Tests/StateTests/DiMsTests.cs
@@ -271,7 +271,7 @@ public class DiMsTests : TestBase
     });
 
     // Act - Run the state machine and send messages
-    await machine.RunAsync(CompositeMsgStateId.Entry, null, null, CancellationToken.None);
+    await machine.RunAsync(CompositeMsgStateId.Entry, CancellationToken.None);
 
     Console.WriteLine("MS.DI workflow finished.");
 

--- a/source/Lite.StateMachine.Tests/TestData/States/BasicStates.cs
+++ b/source/Lite.StateMachine.Tests/TestData/States/BasicStates.cs
@@ -31,12 +31,15 @@ public class BasicState1() : IState<BasicStateId>
     context.Parameters[ParameterType.Counter] = context.ParameterAsInt(ParameterType.Counter) + 1;
     context.NextState(Result.Success);
     Console.WriteLine($"[BasicState1][OnEnter] {context.Parameters[ParameterType.Counter]} => OK");
+    Console.WriteLine($"[BasicState1][OnEnter].OnSuccess '{context.NextStates.OnSuccess}'");
+    Console.WriteLine($"[BasicState1][OnEnter].OnError '{context.NextStates.OnError}'");
+    Console.WriteLine($"[BasicState1][OnEnter].OnFailure '{context.NextStates.OnFailure}'");
   }
 
   public Task OnExit(Context<BasicStateId> context)
   {
     context.Parameters[ParameterType.Counter] = context.ParameterAsInt(ParameterType.Counter) + 1;
-    Console.WriteLine($"[BasicState1][OnExit] {context.Parameters[ParameterType.Counter]}");
+    Console.WriteLine($"[BasicState1][OnExit] Params[Counter]: {context.Parameters[ParameterType.Counter]}");
     return Task.CompletedTask;
   }
 }

--- a/source/Lite.StateMachine.Tests/TestData/States/CommandL3States.cs
+++ b/source/Lite.StateMachine.Tests/TestData/States/CommandL3States.cs
@@ -151,6 +151,9 @@ public class State2_Sub2(IMessageService msg, ILogger<State2_Sub2> log)
   {
     // Demonstrate temporary parameter that will be discarded after State2_Sub2's OnExit
     context.Parameters.Add($"{context.CurrentStateId}!TEMP", Guid.NewGuid());
+
+    Log.LogInformation($"[OnEnter] CurrentStateId: {context.CurrentStateId} PreviousStateId: {context.PreviousStateId}");
+    Assert.AreEqual(StateId.State2_Sub2, context.CurrentStateId);
     return base.OnEnter(context);
   }
 
@@ -158,6 +161,12 @@ public class State2_Sub2(IMessageService msg, ILogger<State2_Sub2> log)
   {
     // Expected Count: 7
     MessageService.Counter3 = context.Parameters.Count;
+
+    Log.LogInformation("[OnExit] CurrentStateId: {c} PreviousStateId: {p}", context.CurrentStateId, context.PreviousStateId);
+    Assert.AreEqual(StateId.State2_Sub2, context.CurrentStateId);
+    Assert.AreEqual(StateId.State2_Sub1, context.PreviousStateId);
+    Assert.AreEqual(StateId.State2_Sub2_Sub3, context.LastChildStateId);
+    Assert.AreEqual(Result.Success, context.LastChildResult);
     return base.OnExit(context);
   }
 }
@@ -189,6 +198,9 @@ public class State2_Sub2_Sub2(IMessageService msg, ILogger<State2_Sub2_Sub2> log
     //  1) We're sending the same OpenCommand to prove that State1's OnMessage isn't called a 2nd time.
     //  2) CloseResponse doesn't reached our OnMessage because we left already.
     context.EventAggregator?.Publish(new UnlockCommand { Counter = 200 });
+
+    Log.LogInformation($"[OnEnter] CurrentStateId: {context.CurrentStateId} PreviousStateId: {context.PreviousStateId}");
+    Assert.AreEqual(StateId.State2_Sub2_Sub2, context.CurrentStateId);
     return base.OnEnter(context);
   }
 
@@ -197,6 +209,9 @@ public class State2_Sub2_Sub2(IMessageService msg, ILogger<State2_Sub2_Sub2> log
     MessageService.Counter4++;
 
     context.NextState(Result.Success);
+
+    Log.LogInformation($"[OnMessage] CurrentStateId: {context.CurrentStateId} PreviousStateId: {context.PreviousStateId}");
+    Assert.AreEqual(StateId.State2_Sub2_Sub2, context.CurrentStateId);
     return base.OnMessage(context, message);
   }
 
@@ -222,6 +237,13 @@ public class State2_Sub3(IMessageService msg, ILogger<State2_Sub3> log)
   {
     context.Parameters.Add(context.CurrentStateId.ToString(), Guid.NewGuid());
     MessageService.AddMessage($"[Keys-{context.CurrentStateId}]: {string.Join(",", context.Parameters.Keys)}");
+
+    // NOTE: We the state following the composite doesn't know about "LastChildXXX".
+    Log.LogInformation($"[OnEnter] CurrentStateId: {context.CurrentStateId} PreviousStateId: {context.PreviousStateId}");
+    Assert.AreEqual(StateId.State2_Sub3, context.CurrentStateId);
+    Assert.AreEqual(StateId.State2_Sub2, context.PreviousStateId);
+    Assert.IsNull(context.LastChildStateId);
+    Assert.IsNull(context.LastChildResult);
     return base.OnEnter(context);
   }
 }
@@ -234,6 +256,9 @@ public class State3(IMessageService msg, ILogger<State3> log)
   {
     context.Parameters.Add(context.CurrentStateId.ToString(), Guid.NewGuid());
     MessageService.AddMessage($"[Keys-{context.CurrentStateId}]: {string.Join(",", context.Parameters.Keys)}");
+
+    Log.LogInformation($"[OnEnter] CurrentStateId: {context.CurrentStateId} PreviousStateId: {context.PreviousStateId}");
+    Assert.AreEqual(StateId.State3, context.CurrentStateId);
     return base.OnEnter(context);
   }
 }

--- a/source/Lite.StateMachine/Context.cs
+++ b/source/Lite.StateMachine/Context.cs
@@ -19,16 +19,17 @@ public sealed class Context<TStateId>
 
 #pragma warning restore SA1401 // Fields should be private
 
-  private readonly TaskCompletionSource<Result> _tcs;
+  ////private readonly TaskCompletionSource<Result> _tcs;
+  private TaskCompletionSource<Result> _tcs;
 
   internal Context(
-    TStateId current,
+    TStateId currentStateId,
     StateMap<TStateId> nextStates,
     TaskCompletionSource<Result> tcs,
     IEventAggregator? eventAggregator = null,
     Result? lastChildResult = null)
   {
-    CurrentStateId = current;
+    CurrentStateId = currentStateId;
     NextStates = nextStates;
     _tcs = tcs;
     EventAggregator = eventAggregator;
@@ -36,22 +37,42 @@ public sealed class Context<TStateId>
   }
 
   /// <summary>Gets the current State's Id.</summary>
-  public TStateId CurrentStateId { get; }
+  public TStateId CurrentStateId { get; private set; }
 
   /// <summary>Gets or sets an arbitrary collection of errors to pass along to the next state.</summary>
   public PropertyBag Errors { get; set; } = [];
 
   /// <summary>Gets the Event aggregator for Command states (optional).</summary>
-  public IEventAggregator? EventAggregator { get; }
+  public IEventAggregator? EventAggregator { get; private set; }
 
   /// <summary>Gets result emitted by the last child state (for composite parents only).</summary>
-  public Result? LastChildResult { get; }
+  public Result? LastChildResult { get; private set; }
 
   /// <summary>Gets or sets an arbitrary parameter provided by caller to the current action.</summary>
   public PropertyBag Parameters { get; set; } = [];
 
   /// <summary>Gets the previous state's enum value.</summary>
   public TStateId? PreviousStateId { get; internal set; }
+
+  /// <summary>Not for user consumption. Configures Context for state transitions.</summary>
+  /// <param name="tcs">Task Completion Source.</param>
+  /// <param name="currentStateId">Current state that we're in.</param>
+  /// <param name="previousStateId">State which sent us here.</param>
+  public void Configure(TaskCompletionSource<Result> tcs, TStateId currentStateId, TStateId? previousStateId)
+  {
+    _tcs = tcs;
+    CurrentStateId = currentStateId;
+    PreviousStateId = previousStateId;
+  }
+
+  /// <summary>Not for user consumption. Configures Context for composite state transitions.</summary>
+  /// <param name="tcs">Task Completion Source.</param>
+  /// <param name="lastChildResult">State which sent us here.</param>
+  public void Configure(TaskCompletionSource<Result> tcs, Result? lastChildResult)
+  {
+    _tcs = tcs;
+    LastChildResult = lastChildResult;
+  }
 
   /// <summary>Signal the machine to move forward (only once per state entry).</summary>
   /// <param name="result">Result to pass to the next state.</param>

--- a/source/Lite.StateMachine/Context.cs
+++ b/source/Lite.StateMachine/Context.cs
@@ -48,6 +48,9 @@ public sealed class Context<TStateId>
   /// <summary>Gets result emitted by the last child state (for composite parents only).</summary>
   public Result? LastChildResult { get; private set; }
 
+  /// <summary>Gets the last child <see cref="TStateId"/> (for composite parents only).</summary>
+  public TStateId? LastChildStateId { get; private set; }
+
   /// <summary>Gets or sets an arbitrary parameter provided by caller to the current action.</summary>
   public PropertyBag Parameters { get; set; } = [];
 
@@ -65,12 +68,18 @@ public sealed class Context<TStateId>
     PreviousStateId = previousStateId;
   }
 
-  /// <summary>Not for user consumption. Configures Context for composite state transitions.</summary>
+  /// <summary>Not for user consumption. Configures Composite Context state transitions.</summary>
   /// <param name="tcs">Task Completion Source.</param>
-  /// <param name="lastChildResult">State which sent us here.</param>
-  public void Configure(TaskCompletionSource<Result> tcs, Result? lastChildResult)
+  /// <param name="currentStateId">Current state that we're in.</param>
+  /// <param name="previousStateId">State which sent us here.</param>
+  /// <param name="lastChildStateId">Last child state's <see cref="TStateId?"/>.</param>
+  /// <param name="lastChildResult">Last child state's <see cref="Result?"/> which sent us here.</param>
+  public void Configure(TaskCompletionSource<Result> tcs, TStateId currentStateId, TStateId? previousStateId, TStateId? lastChildStateId, Result? lastChildResult)
   {
     _tcs = tcs;
+    CurrentStateId = currentStateId;
+    PreviousStateId = previousStateId;
+    LastChildStateId = lastChildStateId;
     LastChildResult = lastChildResult;
   }
 

--- a/source/Lite.StateMachine/IStateMachine.cs
+++ b/source/Lite.StateMachine/IStateMachine.cs
@@ -105,10 +105,11 @@ public interface IStateMachine<TStateId>
 
   /// <summary>Starts the machine at the initial state.</summary>
   /// <param name="initialState">Initial startup state.</param>
-  /// <param name="parameterStack">Parameter stack <see cref="PropertyBag"/>.</param>
-  /// <param name="errors">Error stack <see cref="PropertyBag"/>.</param>
   /// <param name="cancellationToken">Cancellation Token.</param>
   /// <returns>Async task of The current <see cref="StateMachine{TStateId}"/> instance, enabling method chaining.</returns>
   /// <exception cref="InvalidOperationException">Thrown if the specified state identifier has not been registered.</exception>
-  Task<StateMachine<TStateId>> RunAsync(TStateId initialState, PropertyBag? parameterStack = null, PropertyBag? errors = null, CancellationToken cancellationToken = default);
+  Task<StateMachine<TStateId>> RunAsync(TStateId initialState, CancellationToken cancellationToken = default);
+  /////// <param name="parameterStack">Parameter stack <see cref="PropertyBag"/>.</param>
+  /////// <param name="errors">Error stack <see cref="PropertyBag"/>.</param>
+  ////Task<StateMachine<TStateId>> RunAsync(TStateId initialState, PropertyBag? parameterStack = null, PropertyBag? errors = null, CancellationToken cancellationToken = default);
 }

--- a/source/Lite.StateMachine/Lite.StateMachine.csproj
+++ b/source/Lite.StateMachine/Lite.StateMachine.csproj
@@ -11,7 +11,7 @@
     <AssemblyVersion>2.3.0</AssemblyVersion>
     <FileVersion>$(AssemblyVersion)</FileVersion>
     <VersionPrefix>$(AssemblyVersion)</VersionPrefix>
-    <VersionSuffix>-alpha1</VersionSuffix>
+    <VersionSuffix>-alpha2</VersionSuffix>
     <Version>$(VersionPrefix)$(VersionSuffix)</Version>
 
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/source/Lite.StateMachine/StateMachine.cs
+++ b/source/Lite.StateMachine/StateMachine.cs
@@ -29,9 +29,6 @@ public sealed partial class StateMachine<TStateId> : IStateMachine<TStateId>
   /// <summary>States registered with system.</summary>
   private readonly Dictionary<TStateId, StateRegistration<TStateId>> _states = [];
 
-  ////private IDisposable? _subscription;
-  ////private CancellationTokenSource? _timeoutCts;
-
   /// <summary>
   ///   Initializes a new instance of the <see cref="StateMachine{TStateId}"/> class.
   ///   Dependency Injection is optional:
@@ -53,20 +50,26 @@ public sealed partial class StateMachine<TStateId> : IStateMachine<TStateId>
     _eventAggregator = eventAggregator;
     IsContextPersistent = isContextPersistent;
 
+    Context = new Context<TStateId>(
+      currentStateId: default,
+      nextStates: new StateMap<TStateId> { OnSuccess = null, OnError = null, OnFailure = null },
+      tcs: default!,
+      eventAggregator: _eventAggregator);
+
     // NOTE-1 (2025-12-25):
     //  * Create Precheck Sanitization:
     //    * Verify initial states are set for core and all sub-states.
     //    * Verify any transition exceptions (i.e. DisjointedNextSubStateException)
     //
-    //// OLD-4d3, 4bx:
+    //// OLD-4d3, 4bx 'IServiceResolver' container helper:
     ////  public StateMachine(IServiceResolver? services = null, IEventAggregator? eventAggregator = null, ILogger<StateMachine<TStateId>>? logs = null)
     ////  _services = services;
     ////  _logger = logs;
   }
 
   /// <inheritdoc/>
-  public Context<TStateId> Context { get; private set; } = new Context<TStateId>(default, default, default!, null);
-  ////public Context<TStateId> Context { get; private set; } = default!;
+  ////public Context<TStateId> Context { get; private set; } = new Context<TStateId>(default, default, default!, null);
+  public Context<TStateId> Context { get; private set; } = default!;
 
   /// <inheritdoc/>
   public int DefaultCommandTimeoutMs { get; set; } = 3000;
@@ -79,6 +82,27 @@ public sealed partial class StateMachine<TStateId> : IStateMachine<TStateId>
 
   /// <inheritdoc/>
   public List<TStateId> States => [.. _states.Keys];
+
+  /// <summary>Preload properties and errors to the context.</summary>
+  /// <param name="parameters">Parameter properties to safely add/update.</param>
+  /// <param name="errors">Error properties to safely add/update.</param>
+  /// <returns>Instance of this class.</returns>
+  public StateMachine<TStateId> AddContext(PropertyBag? parameters = null, PropertyBag? errors = null)
+  {
+    if (parameters is not null)
+    {
+      foreach (var item in parameters)
+        Context.Parameters.SafeAdd(item.Key, item.Value);
+    }
+
+    if (errors is not null)
+    {
+      foreach (var item in errors)
+        Context.Parameters.SafeAdd(item.Key, item.Value);
+    }
+
+    return this;
+  }
 
   /// <inheritdoc/>
   public StateMachine<TStateId> RegisterComposite<TCompositeParent>(
@@ -200,8 +224,6 @@ public sealed partial class StateMachine<TStateId> : IStateMachine<TStateId>
   /// <inheritdoc/>
   public async Task<StateMachine<TStateId>> RunAsync(
     TStateId initialStateId,
-    PropertyBag? parameterStack = null,
-    PropertyBag? errorStack = null,
     CancellationToken cancellationToken = default)
   {
     if (!_states.ContainsKey(initialStateId))
@@ -210,31 +232,24 @@ public sealed partial class StateMachine<TStateId> : IStateMachine<TStateId>
     TStateId? prevStateId = null;
     var currentStateId = initialStateId;
 
-    // TBD
-    ////Context = new Context<TStateId>(currentStateId, default, default!, null);
+    // Make sure we're always initialized
+    Context ??= new Context<TStateId>(
+      currentStateId: default,
+      nextStates: new StateMap<TStateId> { OnSuccess = null, OnError = null, OnFailure = null },
+      tcs: default!,
+      eventAggregator: _eventAggregator);
 
     while (!cancellationToken.IsCancellationRequested)
     {
       var reg = GetRegistration(currentStateId);
       reg.PreviousStateId = prevStateId;
 
-      // TODO (2025-12-28 DS): Configure context and pass it along
-      ////var tcs = new TaskCompletionSource<Result>(TaskCreationOptions.RunContinuationsAsynchronously);
-      ////var ctx = new Context<TStateId>(reg.StateId, tcs, _eventAggregator)
-      ////{
-      ////  Parameters = parameterStack ?? [],
-      ////  Errors = errorStack ?? [],
-      ////};
-
-      ////Context.Parameters = parameterStack ?? [];
-      ////Context.Errors = errorStack ?? [];
-
-      parameterStack ??= [];
-      errorStack ??= [];
+      // Ensure we're always initialized
+      Context.Parameters = Context.Parameters ?? [];
+      Context.Errors = Context.Errors ?? [];
 
       // Run any state (composite or leaf) recursively.
-      var result = await RunAnyStateRecursiveAsync(reg, parameterStack, errorStack, cancellationToken).ConfigureAwait(false);
-      ////var result = await RunAnyStateRecursiveAsync(reg, cancellationToken).ConfigureAwait(false);
+      var result = await RunAnyStateRecursiveAsync(reg, cancellationToken).ConfigureAwait(false);
       if (result is null)
         break;
 
@@ -295,38 +310,24 @@ public sealed partial class StateMachine<TStateId> : IStateMachine<TStateId>
 
   private async Task<Result?> RunAnyStateRecursiveAsync(
     StateRegistration<TStateId> reg,
-    PropertyBag? parameters,
-    PropertyBag? errors,
     CancellationToken ct)
   {
-    // Ensure we always operate on non-null, shared bags
-    ////parameters ??= [];
-    ////errors ??= [];
-
     // Run Normal or Command State
     if (!reg.IsCompositeParent)
-      ////return await RunLeafAsync(reg, ct).ConfigureAwait(false);
-      return await RunLeafAsync(reg, parameters, errors, ct).ConfigureAwait(false);
+      return await RunLeafAsync(reg, ct).ConfigureAwait(false);
 
     // Composite States
     var instance = GetOrCreateInstance(reg);
 
-    StateMap<TStateId> nextStates = new()
-    {
-      OnSuccess = reg.OnSuccess,
-      OnError = reg.OnError,
-      OnFailure = reg.OnFailure,
-    };
+    Context.Configure(
+      new TaskCompletionSource<Result>(TaskCreationOptions.RunContinuationsAsynchronously),
+      reg.StateId,
+      reg.PreviousStateId);
+    Context.NextStates.OnSuccess = reg.OnSuccess;
+    Context.NextStates.OnError = reg.OnError;
+    Context.NextStates.OnFailure = reg.OnFailure;
 
-    var parentEnterTcs = new TaskCompletionSource<Result>(TaskCreationOptions.RunContinuationsAsynchronously);
-    var parentEnterCtx = new Context<TStateId>(reg.StateId, nextStates, parentEnterTcs, _eventAggregator)
-    {
-      Parameters = parameters,
-      Errors = errors,
-      PreviousStateId = reg.PreviousStateId,
-    };
-
-    await instance.OnEntering(parentEnterCtx).ConfigureAwait(false);
+    await instance.OnEntering(Context).ConfigureAwait(false);
 
     // [IsContextPersistent]
     //  Take snapshot of original Context keys AFTER OnEntering so we can give the state a chance
@@ -334,15 +335,10 @@ public sealed partial class StateMachine<TStateId> : IStateMachine<TStateId>
     //
     //  Any new Context keys added via OnEnter are considered "for children consumption only".
     //  After our OnExit, they'll be (optionally) removed.
-    var originalParamKeys = new HashSet<object>(parameters.Keys);
-    var originalErrorKeys = new HashSet<object>(errors.Keys);
+    var originalParamKeys = new HashSet<object>(Context.Parameters.Keys);
+    var originalErrorKeys = new HashSet<object>(Context.Errors.Keys);
 
-    await instance.OnEnter(parentEnterCtx).ConfigureAwait(false);
-
-    // Check for next transition overrides
-    ////reg.OnSuccess = parentEnterCtx.NextStates.OnSuccess;
-    ////reg.OnError = parentEnterCtx.NextStates.OnError;
-    ////reg.OnFailure = parentEnterCtx.NextStates.OnFailure;
+    await instance.OnEnter(Context).ConfigureAwait(false);
 
     // TODO (2025-12-28 DS): Consider StateMachine config param to just move along or throw exception
     if (reg.InitialChildId is null)
@@ -364,18 +360,16 @@ public sealed partial class StateMachine<TStateId> : IStateMachine<TStateId>
       if (!Equals(childReg.ParentId, reg.StateId))
         throw new OrphanSubStateException($"Child state '{childId}' must belong to composite '{reg.StateId}'.");
 
-      // Could just call "RunAnyStateRecursiveAsync" but lets not waste cycles
       Result? childResult;
       if (childReg.IsCompositeParent)
-        childResult = await RunAnyStateRecursiveAsync(childReg, parameters, errors, ct).ConfigureAwait(false);
+        childResult = await RunAnyStateRecursiveAsync(childReg, ct).ConfigureAwait(false);
       else
-        childResult = await RunLeafAsync(childReg, parameters, errors, ct).ConfigureAwait(false);
+        childResult = await RunLeafAsync(childReg, ct).ConfigureAwait(false);
 
       // Cancelled or timed out inside child state
       if (childResult is null)
         return null;
 
-      // TODO (#76): Extract the Context.OnSuccess/Error/Failure override (if any)
       lastChildResult = childResult;
       var nextChildId = StateMachine<TStateId>.ResolveNext(childReg, childResult.Value);
 
@@ -396,13 +390,15 @@ public sealed partial class StateMachine<TStateId> : IStateMachine<TStateId>
     // Parent's OnExit decides Ok/Error/Failure; Inform parent of last child's result via Context
     // TODO (2025-12-28 DS): Pass one Context object. Just clear "lastChildResult" after the OnExit.
     var parentExitTcs = new TaskCompletionSource<Result>(TaskCreationOptions.RunContinuationsAsynchronously);
-    var parentExitCtx = new Context<TStateId>(reg.StateId, nextStates, parentExitTcs, _eventAggregator, lastChildResult)
-    {
-      Parameters = parameters ?? [],
-      Errors = errors ?? [],
-    };
 
-    await instance.OnExit(parentExitCtx).ConfigureAwait(false);
+    Context.Configure(parentExitTcs, lastChildResult);
+
+    // vNext (2025-12-28 DS): Use `OnState` handler to handle children completion instead of OnExit
+    ////await instance.OnState(Context).ConfigureAwait(false);
+    ////var parentDecision = await WaitForNextOrCancelAsync(parentExitTcs.Task, ct).ConfigureAwait(false);
+
+    // TODO (2025-01-10 DS): Double check the Context's CurrentStateId, NextStates.OnSuccess/Error/Failure match our parent state. Not leftover child garbage
+    await instance.OnExit(Context).ConfigureAwait(false);
 
     // To avoid composite state's OnExit, use the DefaultStateTimeoutMs to auto-cancel wait.
     var parentDecision = await WaitForNextOrCancelAsync(parentExitTcs.Task, ct).ConfigureAwait(false);
@@ -410,16 +406,16 @@ public sealed partial class StateMachine<TStateId> : IStateMachine<TStateId>
     // Optionally cleanup context added by the children; giving the parent a peek at their mess.
     if (!IsContextPersistent)
     {
-      if (parameters is not null)
+      if (Context.Parameters is not null)
       {
-        foreach (var k in parameters.Keys)
-          if (!originalParamKeys.Contains(k)) parameters.Remove(k);
+        foreach (var k in Context.Parameters.Keys)
+          if (!originalParamKeys.Contains(k)) Context.Parameters.Remove(k);
       }
 
-      if (errors is not null)
+      if (Context.Errors is not null)
       {
-        foreach (var k in errors.Keys)
-          if (!originalErrorKeys.Contains(k)) errors.Remove(k);
+        foreach (var k in Context.Errors.Keys)
+          if (!originalErrorKeys.Contains(k)) Context.Errors.Remove(k);
       }
     }
 
@@ -430,40 +426,29 @@ public sealed partial class StateMachine<TStateId> : IStateMachine<TStateId>
     return parentDecision;
   }
 
-  // Rename: RunSingleStateAsync(...)
+  // Rename (2015-12-28 DS): RunSingleStateAsync(...)
   private async Task<Result?> RunLeafAsync(
     StateRegistration<TStateId> reg,
-    PropertyBag? parameterStack,
-    PropertyBag? errorStack,
     CancellationToken cancellationToken)
   {
     IState<TStateId> instance = GetOrCreateInstance(reg);
 
-    // Next state transitions
-    StateMap<TStateId> nextStates = new()
-    {
-      OnSuccess = reg.OnSuccess,
-      OnError = reg.OnError,
-      OnFailure = reg.OnFailure,
-    };
-
     var tcs = new TaskCompletionSource<Result>(TaskCreationOptions.RunContinuationsAsynchronously);
-    var ctx = new Context<TStateId>(reg.StateId, nextStates, tcs, _eventAggregator)
-    {
-      Parameters = parameterStack ?? [],
-      Errors = errorStack ?? [],
-      PreviousStateId = reg.PreviousStateId,
-    };
+    Context.Configure(tcs, reg.StateId, reg.PreviousStateId);
+    Context.NextStates.OnSuccess = reg.OnSuccess;
+    Context.NextStates.OnError = reg.OnError;
+    Context.NextStates.OnFailure = reg.OnFailure;
 
     IDisposable? subscription = null;
     CancellationTokenSource? timeoutCts = null;
 
+    // TODO (2026-01-10 DS): Is is possible for OnMessage to happen before OnEntering/OnEnter?
     if (instance is ICommandState<TStateId> cmd)
     {
       if (_eventAggregator is not null)
       {
         // Subscribed message types or `Array.Empty<Type>()` for none
-        //// vNext: IReadOnlyCollection<Type> types2 = [.. cmd.SubscribedMessageTypes ?? [], .. reg.SubscribedMessageTypes ?? []];
+        //// vNext (#89): IReadOnlyCollection<Type> types2 = [.. cmd.SubscribedMessageTypes ?? [], .. reg.SubscribedMessageTypes ?? []];
         var types = cmd.SubscribedMessageTypes ?? [];
 
         subscription = _eventAggregator.Subscribe(async (msgObj) =>
@@ -473,7 +458,7 @@ public sealed partial class StateMachine<TStateId> : IStateMachine<TStateId>
 
 #pragma warning disable SA1501 // Statement should not be on a single line
           // Swallow to avoid breaking publication loop
-          try { await cmd.OnMessage(ctx, msgObj).ConfigureAwait(false); } catch { }
+          try { await cmd.OnMessage(Context, msgObj).ConfigureAwait(false); } catch { }
 #pragma warning restore SA1501 // Statement should not be on a single line
         },
         [.. types]);   //// [.. types] == types.ToArray()
@@ -488,7 +473,7 @@ public sealed partial class StateMachine<TStateId> : IStateMachine<TStateId>
             {
               await Task.Delay(timeoutMs, timeoutCts.Token).ConfigureAwait(false);
               if (!tcs.Task.IsCompleted && !timeoutCts.IsCancellationRequested)
-                await cmd.OnTimeout(ctx).ConfigureAwait(false);
+                await cmd.OnTimeout(Context).ConfigureAwait(false);
             }
             catch (TaskCanceledException)
             {
@@ -502,21 +487,20 @@ public sealed partial class StateMachine<TStateId> : IStateMachine<TStateId>
 
     try
     {
-      await instance.OnEntering(ctx).ConfigureAwait(false);
-      await instance.OnEnter(ctx).ConfigureAwait(false);
+      await instance.OnEntering(Context).ConfigureAwait(false);
+      await instance.OnEnter(Context).ConfigureAwait(false);
 
       var result = await WaitForNextOrCancelAsync(tcs.Task, cancellationToken).ConfigureAwait(false);
 
       // TODO (2025-12-28 DS): Potential DefaultStateTimeoutMs. Even leaving OnEnter without NextState(Result.OK), should consider calling `OnExit` to allow states to cleanup.
-      // TODO (2026-01-04 DS): Consider handling "OnTRANSITION" overrides. Passing a single Context would solve this as it's passed by ref.
       if (result is null)
         return null;
 
-      await instance.OnExit(ctx).ConfigureAwait(false);
+      await instance.OnExit(Context).ConfigureAwait(false);
 
-      reg.OnSuccess = ctx.NextStates.OnSuccess;
-      reg.OnError = ctx.NextStates.OnError;
-      reg.OnFailure = ctx.NextStates.OnFailure;
+      reg.OnSuccess = Context.NextStates.OnSuccess;
+      reg.OnError = Context.NextStates.OnError;
+      reg.OnFailure = Context.NextStates.OnFailure;
 
       return result.Value;
     }

--- a/source/Sample.Basics/States/DemoMachine.cs
+++ b/source/Sample.Basics/States/DemoMachine.cs
@@ -26,11 +26,12 @@ public static class DemoMachine
     };
 
     var machine = new StateMachine<BasicStateId>();
+    machine.AddContext(ctxProperties);
     machine.RegisterState<BasicState1>(BasicStateId.State1, BasicStateId.State2);
     machine.RegisterState<BasicState2>(BasicStateId.State2, BasicStateId.State3);
     machine.RegisterState<BasicState3>(BasicStateId.State3);
 
     // Act - Start your engine!
-    await machine.RunAsync(BasicStateId.State1, ctxProperties);
+    await machine.RunAsync(BasicStateId.State1);
   }
 }


### PR DESCRIPTION
## Details

* Improve Context Memory Allocation; Increasing Throughput
* NEW: `StateMachine.AddContext(parameters, errors);` - Helper method for building context ahead of time
* BREAKING: `StateMachine.RunAsync(...)` - Removed `parameters` and `errors` arguments. Use `.AddContext(..)` instead.

## Linked To Issue/Feature

* #88