### PR TITLE
#89 - RegisterState Subscriptions to Event Aggregator

### DIFF
--- a/source/Lite.StateMachine.Tests/StateTests/CommandStateTests.cs
+++ b/source/Lite.StateMachine.Tests/StateTests/CommandStateTests.cs
@@ -47,11 +47,11 @@ public class CommandStateTests : TestBase
 
     machine
       .AddContext(ctxProperties)
-      .RegisterState<State1>(StateId.State1, StateId.State2)
+      .RegisterState<State1>(StateId.State1, StateId.State2, subscriptionTypes: [typeof(UnlockResponse)])
       .RegisterComposite<State2>(StateId.State2, initialChildStateId: StateId.State2_Sub1, onSuccess: StateId.State3)
       .RegisterSubState<State2_Sub1>(StateId.State2_Sub1, parentStateId: StateId.State2, onSuccess: StateId.State2_Sub2)
       .RegisterSubComposite<State2_Sub2>(StateId.State2_Sub2, parentStateId: StateId.State2, initialChildStateId: StateId.State2_Sub2_Sub1, onSuccess: StateId.State2_Sub3)
-      .RegisterSubState<State2_Sub2_Sub1>(StateId.State2_Sub2_Sub1, parentStateId: StateId.State2_Sub2, onSuccess: StateId.State2_Sub2_Sub2)
+      .RegisterSubState<State2_Sub2_Sub1>(StateId.State2_Sub2_Sub1, parentStateId: StateId.State2_Sub2, onSuccess: StateId.State2_Sub2_Sub2, subscriptionTypes: [typeof(UnlockResponse), typeof(CloseResponse)])
       .RegisterSubState<State2_Sub2_Sub2>(StateId.State2_Sub2_Sub2, parentStateId: StateId.State2_Sub2, onSuccess: StateId.State2_Sub2_Sub3)
       .RegisterSubState<State2_Sub2_Sub3>(StateId.State2_Sub2_Sub3, parentStateId: StateId.State2_Sub2, onSuccess: null)
       .RegisterSubState<State2_Sub3>(StateId.State2_Sub3, parentStateId: StateId.State2, onSuccess: null)
@@ -140,7 +140,11 @@ public class CommandStateTests : TestBase
     Assert.AreEqual(100, counter);
   }
 
+#pragma warning disable SA1124 // Do not use regions
+  #region Infinite Loop Test State Classes
+
   private class InfState1 : IState<StateId>
+#pragma warning restore SA1124 // Do not use regions
   {
     public Task OnEnter(Context<StateId> context)
     {
@@ -178,4 +182,6 @@ public class CommandStateTests : TestBase
 
     public Task OnTimeout(Context<StateId> context) => Task.CompletedTask;
   }
+
+  #endregion Infinite Loop Test State Classes
 }

--- a/source/Lite.StateMachine.Tests/TestData/Services/MessageService.cs
+++ b/source/Lite.StateMachine.Tests/TestData/Services/MessageService.cs
@@ -11,7 +11,7 @@ public interface IMessageService
 {
   /// <summary
   /// Gets or sets a counter.
-  /// <see cref="DiStateBase{TStateClass, TStateId}"/> uses it as an automatic state transition counter.
+  /// <see cref="StateDiBase{TStateClass, TStateId}"/> uses it as an automatic state transition counter.
   /// </summary>
   int Counter1 { get; set; }
 

--- a/source/Lite.StateMachine.Tests/TestData/States/BasicDiStates.cs
+++ b/source/Lite.StateMachine.Tests/TestData/States/BasicDiStates.cs
@@ -10,13 +10,13 @@ namespace Lite.StateMachine.Tests.TestData.States;
 #pragma warning disable SA1402 // File may only contain a single type
 
 public class BasicDiState1(IMessageService msg, ILogger<BasicDiState1> log)
-  : DiStateBase<BasicDiState1, BasicStateId>(msg, log);
+  : StateDiBase<BasicDiState1, BasicStateId>(msg, log);
 
 public class BasicDiState2(IMessageService msg, ILogger<BasicDiState2> log)
-  : DiStateBase<BasicDiState2, BasicStateId>(msg, log);
+  : StateDiBase<BasicDiState2, BasicStateId>(msg, log);
 
 public class BasicDiState3(IMessageService msg, ILogger<BasicDiState3> log)
-  : DiStateBase<BasicDiState3, BasicStateId>(msg, log);
+  : StateDiBase<BasicDiState3, BasicStateId>(msg, log);
 
 #pragma warning restore SA1649 // File name should match first type name
 #pragma warning restore SA1402 // File may only contain a single type

--- a/source/Lite.StateMachine.Tests/TestData/States/CommandL3States.cs
+++ b/source/Lite.StateMachine.Tests/TestData/States/CommandL3States.cs
@@ -31,20 +31,6 @@ public enum StateId
   Error,
 }
 
-public class CommonDiStateBase<TStateClass, TStateId>(IMessageService msg, ILogger<TStateClass> logger)
-  : DiStateBase<TStateClass, TStateId>(msg, logger)
-  where TStateId : struct, Enum
-{
-  // Helper so we don't have to keep rewriting the same "override Task OnEnter(...)"
-  // 8 lines * 9 states.. useless
-  public override Task OnEnter(Context<TStateId> context)
-  {
-    context.Parameters.Add(context.CurrentStateId.ToString(), Guid.NewGuid());
-    MessageService.AddMessage($"[Keys-{context.CurrentStateId}]: {string.Join(",", context.Parameters.Keys)}");
-    return base.OnEnter(context);
-  }
-}
-
 public class State1(IMessageService msg, ILogger<State1> log)
   : CommandStateBase<State1, StateId>(msg, log)
 {
@@ -96,7 +82,7 @@ public class State1(IMessageService msg, ILogger<State1> log)
 
 /// <summary>Level-1: Composite.</summary>
 public class State2(IMessageService msg, ILogger<State2> log)
-  : CommonDiStateBase<State2, StateId>(msg, log)
+  : StateDiMessageBase<State2, StateId>(msg, log)
 {
   #region CodeMaid - Suppress method sorting
 
@@ -127,14 +113,14 @@ public class State2(IMessageService msg, ILogger<State2> log)
 
 /// <summary>Sublevel-2: State.<summary>
 public class State2_Sub1(IMessageService msg, ILogger<State2_Sub1> log)
-  : CommonDiStateBase<State2_Sub1, StateId>(msg, log)
+  : StateDiMessageBase<State2_Sub1, StateId>(msg, log)
 {
   public override Task OnEnter(Context<StateId> context) => base.OnEnter(context);
 }
 
 /// <summary>Sublevel-2: Composite.</summary>
 public class State2_Sub2(IMessageService msg, ILogger<State2_Sub2> log)
-  : CommonDiStateBase<State2_Sub2, StateId>(msg, log)
+  : StateDiMessageBase<State2_Sub2, StateId>(msg, log)
 {
   #region CodeMaid - DoNotReorder
 
@@ -173,7 +159,7 @@ public class State2_Sub2(IMessageService msg, ILogger<State2_Sub2> log)
 
 /// <summary>Sublevel-3: State.</summary>
 public class State2_Sub2_Sub1(IMessageService msg, ILogger<State2_Sub2_Sub1> log)
-  : CommonDiStateBase<State2_Sub2_Sub1, StateId>(msg, log)
+  : StateDiMessageBase<State2_Sub2_Sub1, StateId>(msg, log)
 {
   public override Task OnEnter(Context<StateId> context) => base.OnEnter(context);
 }
@@ -224,14 +210,14 @@ public class State2_Sub2_Sub2(IMessageService msg, ILogger<State2_Sub2_Sub2> log
 
 /// <summary>Sublevel-3: Last State.</summary>
 public class State2_Sub2_Sub3(IMessageService msg, ILogger<State2_Sub2_Sub3> log)
-: CommonDiStateBase<State2_Sub2_Sub3, StateId>(msg, log)
+: StateDiMessageBase<State2_Sub2_Sub3, StateId>(msg, log)
 {
   public override Task OnEnter(Context<StateId> context) => base.OnEnter(context);
 }
 
 /// <summary>Sublevel-2: Last State.</summary>
 public class State2_Sub3(IMessageService msg, ILogger<State2_Sub3> log)
-  : DiStateBase<State2_Sub3, StateId>(msg, log)
+  : StateDiBase<State2_Sub3, StateId>(msg, log)
 {
   public override Task OnEnter(Context<StateId> context)
   {
@@ -250,7 +236,7 @@ public class State2_Sub3(IMessageService msg, ILogger<State2_Sub3> log)
 
 /// <summary>Make sure not child-created context is there.</summary>
 public class State3(IMessageService msg, ILogger<State3> log)
-  : DiStateBase<State3, StateId>(msg, log)
+  : StateDiBase<State3, StateId>(msg, log)
 {
   public override Task OnEnter(Context<StateId> context)
   {
@@ -259,6 +245,20 @@ public class State3(IMessageService msg, ILogger<State3> log)
 
     Log.LogInformation($"[OnEnter] CurrentStateId: {context.CurrentStateId} PreviousStateId: {context.PreviousStateId}");
     Assert.AreEqual(StateId.State3, context.CurrentStateId);
+    return base.OnEnter(context);
+  }
+}
+
+public class StateDiMessageBase<TStateClass, TStateId>(IMessageService msg, ILogger<TStateClass> logger)
+  : StateDiBase<TStateClass, TStateId>(msg, logger)
+  where TStateId : struct, Enum
+{
+  // Helper so we don't have to keep rewriting the same "override Task OnEnter(...)"
+  // 8 lines * 9 states.. useless
+  public override Task OnEnter(Context<TStateId> context)
+  {
+    context.Parameters.Add(context.CurrentStateId.ToString(), Guid.NewGuid());
+    MessageService.AddMessage($"[Keys-{context.CurrentStateId}]: {string.Join(",", context.Parameters.Keys)}");
     return base.OnEnter(context);
   }
 }

--- a/source/Lite.StateMachine.Tests/TestData/States/CommandL3States.cs
+++ b/source/Lite.StateMachine.Tests/TestData/States/CommandL3States.cs
@@ -35,6 +35,10 @@ public class State1(IMessageService msg, ILogger<State1> log)
   : CommandStateBase<State1, StateId>(msg, log)
 {
   /// <summary>Gets message types for command state to subscribe to.</summary>
+  /// <remarks>
+  ///   Already subscribed to in StateMachine builder. Defining twice to test that we don't
+  ///   get duplicate messages.
+  /// </remarks>
   public override IReadOnlyCollection<Type> SubscribedMessageTypes => new[]
   {
     //// typeof(OpenCommand),  // <---- NOTE: Not needed
@@ -168,12 +172,13 @@ public class State2_Sub2_Sub1(IMessageService msg, ILogger<State2_Sub2_Sub1> log
 public class State2_Sub2_Sub2(IMessageService msg, ILogger<State2_Sub2_Sub2> log)
   : CommandStateBase<State2_Sub2_Sub2, StateId>(msg, log)
 {
-  /// <summary>Gets message types for command state to subscribe to.</summary>
-  public override IReadOnlyCollection<Type> SubscribedMessageTypes =>
-  [
-    typeof(UnlockResponse),
-    typeof(CloseResponse),
-  ];
+  // Already subscribed to in StateMachine builder
+  /////// <summary>Gets message types for command state to subscribe to.</summary>
+  ////public override IReadOnlyCollection<Type> SubscribedMessageTypes =>
+  ////[
+  ////  typeof(UnlockResponse),
+  ////  typeof(CloseResponse),
+  ////];
 
   public override Task OnEnter(Context<StateId> context)
   {

--- a/source/Lite.StateMachine.Tests/TestData/States/CommandStateBase.cs
+++ b/source/Lite.StateMachine.Tests/TestData/States/CommandStateBase.cs
@@ -14,7 +14,7 @@ namespace Lite.StateMachine.Tests.TestData.States;
 /// <typeparam name="TStateClass">State class object.</typeparam>
 /// <typeparam name="TStateId">State Id.</typeparam>
 public class CommandStateBase<TStateClass, TStateId>(IMessageService msg, ILogger<TStateClass> logger)
-  : DiStateBase<TStateClass, TStateId>(msg, logger), ICommandState<TStateId>
+  : StateDiBase<TStateClass, TStateId>(msg, logger), ICommandState<TStateId>
   where TStateId : struct, Enum
 {
   //// NEEDS TESTED: public virtual IReadOnlyCollection<ICustomCommand> SubscribedMessageTypes => [];

--- a/source/Lite.StateMachine.Tests/TestData/States/CompositeL1DiStates.cs
+++ b/source/Lite.StateMachine.Tests/TestData/States/CompositeL1DiStates.cs
@@ -12,12 +12,12 @@ namespace Lite.StateMachine.Tests.TestData.States;
 #pragma warning disable SA1402 // File may only contain a single type
 
 public class EntryState(IMessageService msg, ILogger<EntryState> log)
-  : DiStateBase<EntryState, CompositeMsgStateId>(msg, log)
+  : StateDiBase<EntryState, CompositeMsgStateId>(msg, log)
 {
 }
 
 public class ParentState(IMessageService msg, ILogger<ParentState> log)
-  : DiStateBase<ParentState, CompositeMsgStateId>(msg, log)
+  : StateDiBase<ParentState, CompositeMsgStateId>(msg, log)
 {
   /// <summary>Handle the result from our last child state.</summary>
   /// <param name="context">Context data.</param>
@@ -40,12 +40,12 @@ public class ParentState(IMessageService msg, ILogger<ParentState> log)
 }
 
 public class ParentSub_FetchState(IMessageService msg, ILogger<ParentSub_FetchState> log)
-  : DiStateBase<ParentSub_FetchState, CompositeMsgStateId>(msg, log)
+  : StateDiBase<ParentSub_FetchState, CompositeMsgStateId>(msg, log)
 {
 }
 
 public class ParentSub_WaitMessageState(IMessageService msg, ILogger<ParentSub_WaitMessageState> log)
-  : DiStateBase<ParentSub_WaitMessageState, CompositeMsgStateId>(msg, log),
+  : StateDiBase<ParentSub_WaitMessageState, CompositeMsgStateId>(msg, log),
     ICommandState<CompositeMsgStateId>
 {
   public override Task OnEnter(Context<CompositeMsgStateId> context)
@@ -134,12 +134,12 @@ public class ParentSub_WaitMessageState(IMessageService msg, ILogger<ParentSub_W
 }
 
 public class Workflow_DoneState(IMessageService msg, ILogger<Workflow_DoneState> log)
-  : DiStateBase<Workflow_DoneState, CompositeMsgStateId>(msg, log)
+  : StateDiBase<Workflow_DoneState, CompositeMsgStateId>(msg, log)
 {
 }
 
 public class Workflow_ErrorState(IMessageService msg, ILogger<Workflow_ErrorState> log)
-  : DiStateBase<Workflow_ErrorState, CompositeMsgStateId>(msg, log)
+  : StateDiBase<Workflow_ErrorState, CompositeMsgStateId>(msg, log)
 {
   public override Task OnEnter(Context<CompositeMsgStateId> context)
   {
@@ -158,7 +158,7 @@ public class Workflow_ErrorState(IMessageService msg, ILogger<Workflow_ErrorStat
 }
 
 public class Workflow_FailureState(IMessageService msg, ILogger<Workflow_FailureState> log)
-  : DiStateBase<Workflow_FailureState, CompositeMsgStateId>(msg, log)
+  : StateDiBase<Workflow_FailureState, CompositeMsgStateId>(msg, log)
 {
   public override Task OnEnter(Context<CompositeMsgStateId> context)
   {

--- a/source/Lite.StateMachine.Tests/TestData/States/CompositeL3DiStates.cs
+++ b/source/Lite.StateMachine.Tests/TestData/States/CompositeL3DiStates.cs
@@ -15,7 +15,7 @@ using Microsoft.Extensions.Logging;
 namespace Lite.StateMachine.Tests.TestData.States.CompositeL3DiStates;
 
 public class CommonDiStateBase<TStateClass, TStateId>(IMessageService msg, ILogger<TStateClass> logger)
-  : DiStateBase<TStateClass, TStateId>(msg, logger)
+  : StateDiBase<TStateClass, TStateId>(msg, logger)
   where TStateId : struct, Enum
 {
   // Helper so we don't have to keep rewriting the same "override Task OnEnter(...)"
@@ -29,7 +29,7 @@ public class CommonDiStateBase<TStateClass, TStateId>(IMessageService msg, ILogg
 }
 
 public class State1(IMessageService msg, ILogger<State1> log)
-  : DiStateBase<State1, CompositeL3>(msg, log)
+  : StateDiBase<State1, CompositeL3>(msg, log)
 {
   public override Task OnEnter(Context<CompositeL3> context)
   {
@@ -154,7 +154,7 @@ public class State2_Sub2_Sub3(IMessageService msg, ILogger<State2_Sub2_Sub3> log
 
 /// <summary>Sublevel-2: Last State.</summary>
 public class State2_Sub3(IMessageService msg, ILogger<State2_Sub3> log)
-  : DiStateBase<State2_Sub3, CompositeL3>(msg, log)
+  : StateDiBase<State2_Sub3, CompositeL3>(msg, log)
 {
   public override Task OnEnter(Context<CompositeL3> context)
   {
@@ -169,7 +169,7 @@ public class State2_Sub3(IMessageService msg, ILogger<State2_Sub3> log)
 
 /// <summary>Make sure not child-created context is there.</summary>
 public class State3(IMessageService msg, ILogger<State3> log)
-  : DiStateBase<State3, CompositeL3>(msg, log)
+  : StateDiBase<State3, CompositeL3>(msg, log)
 {
   public override Task OnEnter(Context<CompositeL3> context)
   {

--- a/source/Lite.StateMachine.Tests/TestData/States/StateDiBase.cs
+++ b/source/Lite.StateMachine.Tests/TestData/States/StateDiBase.cs
@@ -11,7 +11,7 @@ namespace Lite.StateMachine.Tests.TestData.States;
 
 #pragma warning disable SA1124 // Do not use regions
 
-public class DiStateBase<TStateClass, TStateId>(IMessageService msg, ILogger<TStateClass> logger) : IState<TStateId>
+public class StateDiBase<TStateClass, TStateId>(IMessageService msg, ILogger<TStateClass> logger) : IState<TStateId>
   where TStateId : struct, Enum
 {
   private readonly ILogger<TStateClass> _logger = logger;

--- a/source/Lite.StateMachine/StateRegistration.cs
+++ b/source/Lite.StateMachine/StateRegistration.cs
@@ -38,6 +38,6 @@ internal sealed class StateRegistration<TStateId>
   /// <summary>Gets the State Id, used by ExportUml for <see cref="RegisterState{TStateClass}(TStateId, TStateId?, TStateId?, TStateId?, Action{StateMachine{TStateId}}?)"./> .</summary>
   public TStateId StateId { get; init; }
 
-  /////// <summary>Gets the messages for <see cref="ICommandState{TStateId}"/> to subscribe to.</summary>
-  ////public System.Collections.Generic.IReadOnlyCollection<Type>? SubscribedMessageTypes { get; init; } = null;
+  /// <summary>Gets the messages for <see cref="ICommandState{TStateId}"/> to subscribe to.</summary>
+  public System.Collections.Generic.IReadOnlyCollection<Type>? SubscribedMessageTypes { get; init; } = null;
 }


### PR DESCRIPTION
## Details

Adds the ability to subscribe to `EventAggregator` message types from the `RegisterState` and `RegisterSubState` methods.

```cs
    machine
      .AddContext(ctxProperties)
      .RegisterState<State1>(StateId.State1, StateId.State2, subscriptionTypes: [typeof(UnlockResponse)])
      // ...
      .RegisterSubState<State2_Sub2_Sub1>(StateId.State2_Sub2_Sub1, parentStateId: StateId.State2_Sub2, onSuccess: StateId.State2_Sub2_Sub2, subscriptionTypes: [typeof(UnlockResponse), typeof(CloseResponse)])
```

The is the equivalent to subscribing from the State itself:

```cs
public class State1() : ICommandState<StateId>
{
  public override IReadOnlyCollection<Type> SubscribedMessageTypes =>
    [ typeof(UnlockResponse) ];

  public Task OnEntering(Context<StateId> context) => Task.CompletedTask;

  public Task OnEnter(Context<StateId> context) => Task.CompletedTask;

  public Task OnMessage(Context<StateId> context, object message) { ... }

  public Task OnTimeout(Context<StateId> context) { ... }

  public Task OnExit(Context<StateId> context) => Task.CompletedTask;
}

```

## Linked To Issue/Feature

* #89